### PR TITLE
Initial serving of tile data over WCS

### DIFF
--- a/src/project/Dependencies.scala
+++ b/src/project/Dependencies.scala
@@ -3,6 +3,7 @@ import sbt._
 object Dependencies {
   val spark             = "org.apache.spark"            %% "spark-core"       % Version.spark % "provided"
   val hadoop            = "org.apache.hadoop"            % "hadoop-client"    % Version.hadoop % "provided"
+  val commonsIO         = "commons-io"                   % "commons-io"       % "2.6"
   val geotrellisS3      = "org.locationtech.geotrellis" %% "geotrellis-s3"    % Version.geotrellis
   val geotrellisSpark   = "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis
   val decline           = "com.monovore"                %% "decline"          % Version.decline

--- a/src/server/build.sbt
+++ b/src/server/build.sbt
@@ -9,6 +9,10 @@ libraryDependencies ++= Seq(
   circeCore,
   circeGeneric,
   circeParser,
+  commonsIO,
   ficus,
-  scalatest
+  geotrellisS3,
+  geotrellisSpark,
+  scalatest,
+  spark
 )

--- a/src/server/src/main/resources/application.conf
+++ b/src/server/src/main/resources/application.conf
@@ -4,5 +4,6 @@ http {
 }
 
 server {
-     "catalog": "/dummy"
+     #"catalog": "s3://geotrellis-test/dg-srtm/"
+     "catalog": "s3://azavea-datahub/catalog"
 }

--- a/src/server/src/main/scala/geotrellis/server/Router.scala
+++ b/src/server/src/main/scala/geotrellis/server/Router.scala
@@ -3,6 +3,7 @@ package geotrellis.server
 import geotrellis.server.wcs.WcsRoute
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
@@ -10,6 +11,7 @@ import cats.data.Validated
 import Validated._
 import com.typesafe.scalalogging.LazyLogging
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.xml.NodeSeq
 
 class Router(implicit val system: ActorSystem, implicit val materializer: ActorMaterializer) extends LazyLogging {
@@ -23,5 +25,9 @@ class Router(implicit val system: ActorSystem, implicit val materializer: ActorM
       pathEndOrSingleSlash {
         WcsRoute.root
       }
+    } ~
+    path("kill") {
+      Http().shutdownAllConnectionPools() andThen { case _ => system.terminate() }
+      complete("Shutting down app")
     }
 }

--- a/src/server/src/main/scala/geotrellis/server/wcs/WcsRoute.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/WcsRoute.scala
@@ -2,6 +2,8 @@ package geotrellis.server.wcs
 
 import geotrellis.server.wcs.params._
 import geotrellis.server.wcs.ops._
+import geotrellis.spark._
+import geotrellis.spark.io._
 
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.server._
@@ -9,36 +11,69 @@ import akka.http.scaladsl.server.Directives._
 import cats.data.Validated
 import Validated._
 import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.config.ConfigFactory
+import geotrellis.spark.io.AttributeStore
 
+import scala.util.Try
 import scala.xml.NodeSeq
 
 object WcsRoute extends LazyLogging {
-  def root =
-    get {
-      parameterMultiMap { params =>
-        WCSParams(params) match {
+  type MetadataCatalog = Map[String, (Seq[Int], Option[TileLayerMetadata[SpatialKey]])]
 
-          case Invalid(errors) =>
-            complete {
-              val msg = WCSParamsError.generateErrorMessage(errors.toList)
-              s"""Error parsing parameters: ${msg}"""
-            }
-          case Valid(wcsParams) =>
-            wcsParams match {
-              case p: GetCapabilitiesWCSParams =>
-                complete {
-                  GetCapabilities.build(p)
-                }
-              case p: DescribeCoverageWCSParams =>
-                complete {
-                  DescribeCoverage.build(p)
-                }
-              case p: GetCoverageWCSParams =>
-                complete {
-                  GetCoverage.build(p)
-                }
-            }
+  val catalogMetadata = {
+    val catalogURI = Try(ConfigFactory.load().getString("server.catalog")).toOption
+    val as: AttributeStore = catalogURI match {
+      case Some(uri) => AttributeStore(uri)
+      case None => throw new IllegalArgumentException("""Must specify a value for "server.catalog" in application.conf""")
+    }
+
+    println(s"Loading metadata for catalog at ${catalogURI.get} ...")
+    as
+      .layerIds
+      .sortWith{ (a, b) => a.name < b.name || (a.name == b.name && a.zoom > b.zoom) }
+      .groupBy(_.name)
+      .mapValues(_.map(_.zoom))
+      .map{ case (name, zooms) => {
+        println(s"  -> $name @ zoom=${zooms.head}")
+        val metadata = Try(as.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(name, zooms.head))).toOption
+        name -> (zooms, metadata)
+      }}
+  }
+
+  def root =
+    get { ctx =>
+      extractUri { uri =>
+        println(s"Request received: $uri")
+        parameterMultiMap { params =>
+          WCSParams(params) match {
+
+            case Invalid(errors) =>
+              complete {
+                val msg = WCSParamsError.generateErrorMessage(errors.toList)
+                println(s"""Error parsing parameters: ${msg}""")
+                s"""Error parsing parameters: ${msg}"""
+              }
+            case Valid(wcsParams) =>
+              wcsParams match {
+                case p: GetCapabilitiesWCSParams =>
+                  val link = s"${uri.scheme}://${uri.authority}${uri.path}?"
+                  println(s"GetCapabilities request arrived at $link")
+                  complete {
+                    GetCapabilities.build(link, catalogMetadata, p)
+                  }
+                case p: DescribeCoverageWCSParams =>
+                  println(s"DescribeCoverage request arrived at $uri")
+                  complete {
+                    DescribeCoverage.build(catalogMetadata, p)
+                  }
+                case p: GetCoverageWCSParams =>
+                  println(s"GetCoverage request arrived at $uri")
+                  complete {
+                    GetCoverage.build(catalogMetadata, p)
+                  }
+              }
+          }
         }
-      }
+      }(ctx)
     }
 }

--- a/src/server/src/main/scala/geotrellis/server/wcs/ops/Common.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/ops/Common.scala
@@ -1,0 +1,21 @@
+package geotrellis.server.wcs.ops
+
+import geotrellis.proj4.CRS
+import geotrellis.vector.Extent
+
+import scala.xml.{Attribute, NodeSeq, Null, Text}
+
+object Common {
+  def crsToUrnString(crs: CRS) =
+    "urn:ogc:def:crs:EPSG::" + crs.epsgCode.map(_.toString).getOrElse("")
+
+  def boundingBox110(ex: Extent, crs: CRS, tagName: String = "ows:BoundingBox") = {
+    val elem = <temp dimensions="2"></temp>
+    val childs = Seq(<ows:LowerCorner>{ex.xmin} {ex.ymin}</ows:LowerCorner>,
+                     <ows:UpperCorner>{ex.xmax} {ex.ymax}</ows:UpperCorner>)
+    if (tagName != "ows:WGS84BoundingBox")
+      elem.copy(label=tagName, child=childs) % Attribute(None, "crs", Text(crsToUrnString(crs)), Null)
+    else
+      elem.copy(label=tagName, child=childs)
+  }
+}

--- a/src/server/src/main/scala/geotrellis/server/wcs/ops/DescribeCoverage.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/ops/DescribeCoverage.scala
@@ -1,9 +1,160 @@
 package geotrellis.server.wcs.ops
 
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.reproject.ReprojectRasterExtent
+import geotrellis.server.wcs.WcsRoute
 import geotrellis.server.wcs.params.DescribeCoverageWCSParams
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.json._
 
 import scala.xml.NodeSeq
 
 object DescribeCoverage {
-  def build(params: DescribeCoverageWCSParams): NodeSeq = ???
+  private def addDescriptions110(catalog: WcsRoute.MetadataCatalog)(identifier: String) = {
+    println(s"Received v1.1.0 DescribeCoverage request for layer $identifier")
+
+    catalog(identifier)._2 match {
+      case Some(metadata) =>
+        val ex = metadata.boundsToExtent(metadata.gridBounds)
+        val crs = metadata.crs
+        val (w, h) = (metadata.gridBounds.width * metadata.tileCols, metadata.gridBounds.height * metadata.tileRows)
+        val re = RasterExtent(ex, w, h)
+        val llre = ReprojectRasterExtent(re, crs, LatLng)
+        val llex = llre.extent
+
+        <CoverageDescription>
+          <Identifier>{ identifier }</Identifier>
+          <Description>Geotrellis layer</Description>
+          <Domain>
+            <SpatialDomain>
+              { Common.boundingBox110(ex.reproject(crs, LatLng), LatLng, "ows:WGS84BoundingBox") }
+              <!-- Orginal projected extent: -->
+              { Common.boundingBox110(ex, crs) }
+              <ows:BoundingBox crs="urn:ogc:def:crs:OGC::imageCRS" dimensions="2">
+                <ows:LowerCorner>0 0</ows:LowerCorner>
+                <ows:UpperCorner>{ "%d %d".format(w, h) }</ows:UpperCorner>
+              </ows:BoundingBox>
+              <GridCRS>
+                <GridBaseCRS>{ Common.crsToUrnString(crs) }</GridBaseCRS>
+                <GridType>urn:ogc:def:method:WCS:1.1:2dGridIn2dCrs</GridType>
+                <GridOrigin>{ ({ loc: (Double, Double) => "%f %f".format(loc._1, loc._2)})(re.gridToMap(0, h - 1)) }</GridOrigin>
+                <GridOffsets>{ "%f %f".format(re.cellwidth, -re.cellheight) }</GridOffsets>
+                <GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+              </GridCRS>
+            </SpatialDomain>
+          </Domain>
+          <Range>
+            <Field>
+              <Identifier>contents</Identifier>
+              <Definition>
+                <AnyValue />
+              </Definition>
+              <InterpolationMethods>
+                <DefaultMethod>nearest neighbor</DefaultMethod>
+                <OtherMethod>bilinear</OtherMethod>
+              </InterpolationMethods>
+            </Field>
+          </Range>
+          <SupportedCRS>{ Common.crsToUrnString(LatLng) }</SupportedCRS>
+          <SupportedFormat>image/tiff</SupportedFormat>
+        </CoverageDescription>
+
+      case None =>
+        val comment = <!-- -->
+        comment.copy(commentText = s"No metadata available for $identifier")
+    }
+  }
+
+  private def addDescriptions100(catalog: WcsRoute.MetadataCatalog)(identifier: String) = {
+    println(s"Received v1.0.0 DescribeCoverage request for layer $identifier")
+
+    catalog(identifier)._2 match {
+      case Some(metadata) =>
+        val ex = metadata.boundsToExtent(metadata.gridBounds)
+        val crs = metadata.crs
+        val (w0, h0) = (metadata.gridBounds.width * metadata.tileCols, metadata.gridBounds.height * metadata.tileRows)
+        val re = RasterExtent(ex, w0, h0)
+        val llre = ReprojectRasterExtent(re, crs, LatLng)
+        val llex = llre.extent
+        val (w, h) = llre.dimensions
+
+        <CoverageOffering>
+          <name>{ identifier }</name>
+          <label>{ identifier }</label>
+          <Description>Geotrellis layer</Description>
+          <lonLatEnvelope srsName="WGS84(DD)">
+            <gml:pos>{llex.xmin} {llex.ymin}</gml:pos>
+            <gml:pos>{llex.xmax} {llex.ymax}</gml:pos>
+          </lonLatEnvelope>
+          <domainSet>
+            <spatialDomain>
+              <gml:Envelope srsName="EPSG:4326">
+                <gml:pos>{llex.xmin} {llex.ymin}</gml:pos>
+                <gml:pos>{llex.xmax} {llex.ymax}</gml:pos>
+              </gml:Envelope>
+              <gml:RectifiedGrid>
+                <gml:limits>
+                  <gml:GridEnvelope>
+                    <gml:low>{ "%d %d".format(0, 0) }</gml:low>
+                    <gml:high>{ "%d %d".format(w - 1, h - 1) }</gml:high>
+                  </gml:GridEnvelope>
+                </gml:limits>
+                <gml:axisName>x</gml:axisName>
+                <gml:axisName>y</gml:axisName>
+                <gml:origin>
+                  <gml:pos>{ ({ loc: (Double, Double) => "%f %f".format(loc._1, loc._2)})(llre.gridToMap(0, h - 1)) }</gml:pos>
+                </gml:origin>
+                <gml:offsetVector>
+                  { "%f 0.0".format(llre.cellwidth) }
+                </gml:offsetVector>
+                <gml:offsetVector>
+                  { "0.0 %f".format(-llre.cellheight) }
+                </gml:offsetVector>
+              </gml:RectifiedGrid>
+            </spatialDomain>
+          </domainSet>
+          <rangeSet>
+            <RangeSet>
+              <name>Band</name>
+              <label>Geotrellis Layer</label>
+            </RangeSet>
+          </rangeSet>
+          <supportedCRSs>
+            <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
+          </supportedCRSs>
+          <supportedFormats>
+            <formats>GeoTIFF</formats>
+          </supportedFormats>
+        </CoverageOffering>
+
+      case None =>
+        val comment = <!-- -->
+        comment.copy(commentText = s"No metadata available for $identifier")
+    }
+  }
+
+  def build(metadata: WcsRoute.MetadataCatalog, params: DescribeCoverageWCSParams): NodeSeq = {
+    if (params.version < "1.1") {
+      <CoverageDescription xmlns="http://www.opengis.net/wcs"
+                           xmlns:xlink="http://www.w3.org/1999/xlink"
+                           xmlns:gml="http://www.opengis.net/gml"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.opengis.net/wcs http://schemas.opengis.net/wcs/1.0.0/describeCoverage.xsd"
+                           version="1.0.0">
+        { params.identifiers.map(addDescriptions100(metadata)(_)) }
+      </CoverageDescription>
+    } else {
+      <CoverageDescriptions xmlns="http://www.opengis.net/wcs/1.1"
+                            xmlns:ows="http://www.opengis.net/ows"
+                            xmlns:xlink="http://www.w3.org/1999/xlink"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns:ogc="http://www.opengis.net/ogc"
+                            xmlns:gml="http://www.opengis.net/gml"
+                            version="1.1.0">
+        { params.identifiers.map(addDescriptions110(metadata)(_)) }
+      </CoverageDescriptions>
+    }
+  }
 }

--- a/src/server/src/main/scala/geotrellis/server/wcs/ops/GetCapabilities.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/ops/GetCapabilities.scala
@@ -1,9 +1,152 @@
 package geotrellis.server.wcs.ops
 
+import geotrellis.server.wcs.WcsRoute
 import geotrellis.server.wcs.params.GetCapabilitiesWCSParams
 
-import scala.xml.NodeSeq
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import scala.util.Try
+import scala.xml._
 
 object GetCapabilities {
-  def build(params: GetCapabilitiesWCSParams): NodeSeq = ???
+  // Cribbed from https://github.com/ngageoint/mrgeo/blob/master/mrgeo-services/mrgeo-services-wcs/src/main/java/org/mrgeo/services/wcs/WcsCapabilities.java
+
+  private def makeElement100(requestURL: String) = {
+    <HTTP>
+      <Get>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href={ requestURL } />
+      </Get>
+      <Post>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href={ requestURL } />
+      </Post>
+    </HTTP>
+  }
+
+  private def makeElement110(requestURL: String, operation: String) = {
+    <ows:Operation name={ operation }>
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href={ requestURL }></ows:Get>
+          <ows:Post xlink:href={ requestURL }></ows:Post>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  }
+
+  private def addLayers100(metadata: WcsRoute.MetadataCatalog) = {
+    metadata.map { case (identifier, (zooms, maybeMetadata)) => {
+      println(s"Adding v1.0.0 tag for $identifier")
+      maybeMetadata match {
+        case Some(metadata) =>
+          val crs = metadata.crs
+          val ex = metadata.extent
+          <CoverageOfferingBrief>
+            <name>{ identifier }</name>
+          </CoverageOfferingBrief>
+        case None =>
+          val comment = <!--  -->
+          comment.copy(commentText = s"Loading of $identifier failed")
+      }
+    }}
+  }
+
+  private def addLayers110(metadata: WcsRoute.MetadataCatalog) = {
+    metadata.map { case (identifier, (zooms, maybeMetadata)) => {
+      println(s"Adding v1.1.0 tag for $identifier")
+      maybeMetadata match {
+        case Some(metadata) =>
+          val crs = metadata.crs
+          val ex = metadata.extent
+          <wcs:CoverageSummary>
+            <wcs:Identifier>{ identifier }</wcs:Identifier>
+            { Common.boundingBox110(ex, crs) }
+            {
+              if (crs.epsgCode.isDefined) {
+                <SupportedCRS>urn:ogs:def:crs:EPSG::{ crs.epsgCode.get.toString }</SupportedCRS>
+              }
+            }
+            <SupportedFormat>image/geotiff</SupportedFormat>
+            <SupportedFormat>image/geotif</SupportedFormat>
+            <SupportedFormat>image/tiff</SupportedFormat>
+            <SupportedFormat>image/tif</SupportedFormat>
+          </wcs:CoverageSummary>
+        case None =>
+          val comment = <!--  -->
+          comment.copy(commentText = s"Loading of $identifier failed")
+      }
+    }}
+  }
+
+  def build(requestURL: String, metadata: WcsRoute.MetadataCatalog, params: GetCapabilitiesWCSParams): NodeSeq = {
+    if (params.version < "1.1.0") {
+      <WCS_Capabilities xmlns="http://www.opengis.net/wcs"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        xmlns:gml="http://www.opengis.net/gml"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation={"http://www.opengis.net/wcs http://schemas.opengeospatial.net/wcs/" + params.version + "/wcsCapabilities.xsd"}
+                        version={params.version}>
+        <Service>
+          <name>OGC:WC</name>
+          <description>Geotrellis Web Coverage Service</description>
+          <label>Geotrellis Web Coverage Service</label>
+          <fees>NONE</fees>
+          <accessConstraints>NONE</accessConstraints>
+        </Service>
+        <Capability>
+          <Request>
+            <GetCapabilities>
+              <DCPType>
+                { makeElement100(requestURL) }
+              </DCPType>
+            </GetCapabilities>
+            <DescribeCoverage>
+              <DCPType>
+                { makeElement100(requestURL) }
+              </DCPType>
+            </DescribeCoverage>
+            <GetCoverage>
+              <DCPType>
+                { makeElement100(requestURL) }
+              </DCPType>
+            </GetCoverage>
+          </Request>
+          <Exception>
+            <Format>application/vnd.ogc.se_xml</Format>
+          </Exception>
+        </Capability>
+        <ContentMetadata>
+          { addLayers100(metadata) }
+        </ContentMetadata>
+      </WCS_Capabilities>
+    } else {
+      // Pulled example template from http://nsidc.org/cgi-bin/atlas_north?service=WCS&request=GetCapabilities&version=1.1.1
+      val version = params.version.split('.')
+      <wcs:Capabilities xmlns:wcs={"http://www.opengis.net/wcs/" + version(0) + "." + version(1)}
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        xmlns:ogc="http://www.opengis.net/ogc"
+                        xmlns:ows="http://www.opengis.net/ows"
+                        xmlns:gml="http://www.opengis.net/gml"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        version={params.version}>
+        <ows:ServiceIdentification>
+          <ows:Title>GeoTrellis Web Coverage Service</ows:Title>
+          <ows:ServiceType>OGS WCS</ows:ServiceType>
+          <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
+          <ows:Fees>NONE</ows:Fees>
+          <ows:AccessConstraints>NONE</ows:AccessConstraints>
+        </ows:ServiceIdentification>
+        <ows:OperationsMetadata>
+          { makeElement110(requestURL, "GetCapabilities") }
+          { makeElement110(requestURL, "DescribeCoverage") }
+          { makeElement110(requestURL, "GetCoverage") }
+        </ows:OperationsMetadata>
+        <ows:ServiceProvider>
+        </ows:ServiceProvider>
+        <wcs:Contents>
+          { addLayers110(metadata) }
+        </wcs:Contents>
+      </wcs:Capabilities>
+    }
+  }
 }

--- a/src/server/src/main/scala/geotrellis/server/wcs/ops/GetCoverage.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/ops/GetCoverage.scala
@@ -1,7 +1,62 @@
 package geotrellis.server.wcs.ops
 
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.crop._
+import geotrellis.raster.reproject._
+import geotrellis.raster.io.geotiff._
+import geotrellis.server.wcs.WcsRoute
 import geotrellis.server.wcs.params.GetCoverageWCSParams
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.stitch._
+
+import com.typesafe.config.ConfigFactory
+
+import scala.util.Try
 
 object GetCoverage {
-  def build(params: GetCoverageWCSParams): Array[Byte] = ???
+  def build(catalog: WcsRoute.MetadataCatalog, params: GetCoverageWCSParams): Array[Byte] = {
+    def valueReader = Try(ConfigFactory.load().getString("server.catalog")).toOption match {
+      case Some(uri) => ValueReader(uri)
+      case None => throw new IllegalArgumentException("""Must specify a value for "server.catalog" in application.conf""")
+    }
+    def as = valueReader.attributeStore
+
+    val (zooms, _) = catalog(params.identifier)
+    val allMD = zooms.sorted.map{ z => (z, as.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(params.identifier, z))) }
+
+    val re = RasterExtent(params.boundingBox, params.width, params.height)
+    val srcCrs = allMD.head._2.crs
+    val srcRE = ReprojectRasterExtent(re, LatLng, srcCrs)
+
+    val requestedZoom =
+      if (zooms.length == 1)
+        zooms(0)
+      else {
+        val dw = allMD.map{ case (z, md) => (z, md.cellwidth - srcRE.cellwidth) }
+        val dh = allMD.map{ case (z, md) => (z, md.cellheight - srcRE.cellheight) }
+
+        // Search for pyramid resolution that is lowest zoom level with finer resolution than request.
+        // In case of failure, requested resolution was finer than finest pyramid level; return the
+        // pyramid base.
+        math.max(dw.find{ case (_, d) => d < 0 }.map(_._1).getOrElse( allMD.last._1 ),
+                 dh.find{ case (_, d) => d < 0 }.map(_._1).getOrElse( allMD.last._1 ))
+      }
+
+    def reader = valueReader.reader[SpatialKey, Tile](LayerId(params.identifier, requestedZoom))
+
+    val metadata = allMD.find{ x => x._1 == requestedZoom }.get._2
+    val crs = metadata.crs
+    val maptrans = metadata.layout.mapTransform
+    val gridBounds = maptrans(srcRE.extent)
+
+    println(s"Requested zoom level=$requestedZoom (AOI has ${srcRE.cellSize}, target has ${metadata.cellSize})")
+
+    val regionTile = gridBounds.coordsIter.toSeq.flatMap{ case (x, y) => Try(SpatialKey(x, y) -> reader.read(SpatialKey(x, y))).toOption }.stitch
+    val region = Raster(regionTile, maptrans(gridBounds)).reproject(srcCrs, LatLng)
+    val extract = region.crop(re.extent)
+
+    GeoTiff(extract, LatLng).toByteArray
+  }
 }

--- a/src/server/src/main/scala/geotrellis/server/wcs/params/ParamMap.scala
+++ b/src/server/src/main/scala/geotrellis/server/wcs/params/ParamMap.scala
@@ -44,14 +44,15 @@ private[params] case class ParamMap(params: Map[String, List[String]]) {
       case Some(version :: Nil) => Valid(version)
       case Some(s) => Invalid(RepeatedParam("version"))
       case None =>
-        // Can send "acceptedversions" instead
-        getParam("acceptedversions") match {
+        // Can send "acceptversions" instead
+        getParam("acceptversions") match {
           case Some(versions :: Nil) =>
             Valid(versions.split(",").max)
           case Some(s) =>
-            Invalid(RepeatedParam("acceptedversions"))
+            Invalid(RepeatedParam("acceptversions"))
           case None =>
-            Invalid(MissingMultiParam(Seq("acceptedversions", "version")))
+            // Version string is optional, reply with highest supported version if omitted
+            Valid("1.1.1")
         }
     }).toValidatedNel
 


### PR DESCRIPTION
This PR builds out the WCS server's ability to serve tile data.  This is only a first pass attempt which serves data in WGS84, regardless of the layer projection.  Layers are assumed to consist of spatially-keyed singleband tiles.

That said, we have tile display in QGIS:
![qgis-nlcd](https://user-images.githubusercontent.com/18410961/35158086-f23441ec-fd2d-11e7-8d80-fcb2c17d8021.png)



Signed-off-by: jpolchlo <jpolchlopek@azavea.com>