### PR TITLE
Add auth to all services

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,9 @@ lazy val http4s =
         kamonSysMetrics,
         kamonPrometheus,
         kamonHttp4s,
-        scalatest
+        scalatest,
+        tsecCommon,
+        tsecHttp4s
       )
     )
 

--- a/core/src/main/scala/geotrellis/server/core/util/RangeReaderUtils.scala
+++ b/core/src/main/scala/geotrellis/server/core/util/RangeReaderUtils.scala
@@ -3,7 +3,7 @@ package geotrellis.server.core.util
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.util.{FileRangeReader, RangeReader}
 import geotrellis.spark.io.s3.util.S3RangeReader
-import geotrellis.spark.io.s3.AmazonS3Client
+import geotrellis.spark.io.s3.{AmazonS3Client => GTAmazonS3Client}
 import geotrellis.spark.io.http.util.HttpRangeReader
 import cats._
 import cats.effect.IO
@@ -47,7 +47,7 @@ object RangeReaderUtils extends LazyLogging {
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
-        val s3Client = new AmazonS3Client(new AWSAmazonS3Client(new DefaultAWSCredentialsProviderChain))
+        val s3Client = new GTAmazonS3Client(new AWSAmazonS3Client(new DefaultAWSCredentialsProviderChain))
         S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client)
 
       case scheme =>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "9000:9000"
       - "9095:9095"
     volumes:
-      - ~/.aws:/root/.aws
+      - $HOME/.aws:/root/.aws
     environment:
       TEST_VAR: "env_var"
       HTTP_PORT: 9000

--- a/http4s/src/main/resources/application.conf
+++ b/http4s/src/main/resources/application.conf
@@ -6,8 +6,8 @@ http {
 }
 
 auth {
-    "signing-key": ${?SIGNING_KEY}
     "signing-key": "REPLACEME"
+    "signing-key": ${?SIGNING_KEY}
 }
 
 catalog {

--- a/http4s/src/main/resources/application.conf
+++ b/http4s/src/main/resources/application.conf
@@ -5,6 +5,10 @@ http {
     "port": ${?HTTP_PORT}
 }
 
+auth {
+    "signingKey": ${?SIGNING_KEY}
+}
+
 catalog {
     "uri": "s3://azavea-datahub/catalog"
 }

--- a/http4s/src/main/resources/application.conf
+++ b/http4s/src/main/resources/application.conf
@@ -6,7 +6,8 @@ http {
 }
 
 auth {
-    "signingKey": ${?SIGNING_KEY}
+    "signing-key": ${?SIGNING_KEY}
+    "signing-key": "REPLACEME"
 }
 
 catalog {

--- a/http4s/src/main/scala/geotrellis/server/http4s/Config.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/Config.scala
@@ -12,7 +12,7 @@ case class Config(http: Config.Http, catalog: Config.Catalog, auth: Config.Auth)
 object Config {
   case class Catalog(uri: URI)
   case class Http(interface: String, port: Int)
-  case class Auth(signingKey: Option[String])
+  case class Auth(signingKey: String)
 
   import pureconfig._
 

--- a/http4s/src/main/scala/geotrellis/server/http4s/Config.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/Config.scala
@@ -7,11 +7,12 @@ import pureconfig.error.ConfigReaderException
 import java.net.URI
 
 
-case class Config(http: Config.Http, catalog: Config.Catalog)
+case class Config(http: Config.Http, catalog: Config.Catalog, auth: Config.Auth)
 
 object Config {
   case class Catalog(uri: URI)
   case class Http(interface: String, port: Int)
+  case class Auth(signingKey: Option[String])
 
   import pureconfig._
 

--- a/http4s/src/main/scala/geotrellis/server/http4s/PingPongService.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/PingPongService.scala
@@ -11,9 +11,7 @@ import org.http4s.implicits._
 
 class PingPongService extends Http4sDsl[IO] with Rejector {
   def routes: AuthedService[Either[String, User], IO] = AuthedService {
-    case GET -> Root as user => rejectUnauthorized(user)(
-      Ok(s"Good job, ${user.right.get}")
-    )
+    case GET -> Root as user => rejectUnauthorized(user)(Ok(s"pong"))
   }
 }
 

--- a/http4s/src/main/scala/geotrellis/server/http4s/PingPongService.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/PingPongService.scala
@@ -1,14 +1,19 @@
 package geotrellis.server.http4s
 
+import geotrellis.server.http4s.auth.{User, Rejector}
+
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import cats.effect.IO
 import org.http4s.dsl.Http4sDsl
+import org.http4s.implicits._
 
 
-class PingPongService extends Http4sDsl[IO] {
-  def routes: HttpService[IO] = HttpService[IO] {
-    case GET -> Root => Ok("pong")
+class PingPongService extends Http4sDsl[IO] with Rejector {
+  def routes: AuthedService[Either[String, User], IO] = AuthedService {
+    case GET -> Root as user => rejectUnauthorized(user)(
+      Ok(s"Good job, ${user.right.get}")
+    )
   }
 }
 

--- a/http4s/src/main/scala/geotrellis/server/http4s/Server.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/Server.scala
@@ -57,7 +57,6 @@ object Server extends StreamApp[IO] with LazyLogging {
     for {
       config     <- Stream.eval(Config.load())
       authM       = AuthMiddleware(AuthenticationBackends.fromConfig(config))
-      _ <- Stream.eval(IO(println(s"Config is: ${config.auth}")))
       client     <- Http1Client.stream[IO]().map(KamonClientSupport(_))
       _          <- Stream.eval(IO.pure(logger.info(s"Initializing server at ${config.http.interface}:${config.http.port}")))
       cog         = new CogService

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
@@ -44,31 +44,43 @@ object AuthenticationBackends extends LazyLogging {
         logger.warn("Signing key not changed from default. Falling back to always successful authentication")
         successful
       }
-      case signingKey => { fromSigningKey(signingKey) }
+      case signingKey => {
+        logger.debug("Constructing auth middleware from configured signing key")
+        fromSigningKey(signingKey)
+      }
     }
   }
 
-  val successful: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
+  val successful: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = {
+    logger.debug("Using 'successful' authentication middleware -- all requests will succeed")
     Kleisli(_ => OptionT.liftF(IO(Right(User(1, "Non-authed service")))))
+  }
 
-  val failed: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
+  val failed: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = {
+    logger.debug("Using 'failed' authentication middleware -- all requests will fail")
     Kleisli(_ => OptionT.liftF(IO(Left("oh no"))))
+  }
 
-  val fromAuthHeader: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = Kleisli(
-    {
-      request => {
-
-        val message = for {
-          header <- request.headers.get(Authorization).toRight("Couldn't find an Authorization header")
-          token <- {
-            if (header.value.replace("Token ", "").length >= 10)
-              Right(header.value.replace("Token ", ""))
-            else Left("Invalid token")
-          }
-          message <- Either.catchOnly[NumberFormatException](token.toLong).leftMap(_.toString)
-        } yield message
-        message.traverse(_ => OptionT.liftF(IO(User(1234, "ljaskdlfjsd"))))
+  val fromAuthHeader: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = {
+    logger.debug("""
+      | Using auth header-based authentication with length check --
+      | auth headers with length > 10 will succeed")
+    """.trim.stripMargin)
+    Kleisli(
+      {
+        request => {
+          val message = for {
+            header <- request.headers.get(Authorization).toRight("Couldn't find an Authorization header")
+            token <- {
+              if (header.value.replace("Token ", "").length >= 10)
+                Right(header.value.replace("Token ", ""))
+              else Left("Invalid token")
+            }
+            message <- Either.catchOnly[NumberFormatException](token.toLong).leftMap(_.toString)
+          } yield message
+          message.traverse(_ => OptionT.liftF(IO(User(1234, "ljaskdlfjsd"))))
+        }
       }
-    }
-  )
+    )
+  }
 }

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
@@ -1,0 +1,37 @@
+package geotrellis.server.http4s.auth
+
+import cats._, cats.effect._, cats.implicits._, cats.data._
+import org.http4s._
+import org.http4s.dsl.io._
+import org.http4s.headers.Authorization
+import org.http4s.implicits._
+
+import scala.util.Random
+
+import java.time._
+
+object AuthenticationBackends {
+  val successful: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
+    Kleisli(_ => OptionT.liftF(IO(Right(User(100, "Joseph P Morrison")))))
+
+  val failed: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
+    Kleisli(_ => OptionT.liftF(IO(Left("oh no"))))
+
+  val fromAuthHeader: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = Kleisli(
+    {
+      request => {
+
+        val message = for {
+          header <- request.headers.get(Authorization).toRight("Couldn't find an Authorization header")
+          token <- {
+            if (header.value.replace("Token ", "").length >= 10)
+              Right(header.value.replace("Token ", ""))
+            else Left("Invalid token")
+          }
+          message <- Either.catchOnly[NumberFormatException](token.toLong).leftMap(_.toString)
+        } yield message
+        message.traverse(_ => OptionT.liftF(IO(User(1234, "ljaskdlfjsd"))))
+      }
+    }
+  )
+}

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
@@ -1,18 +1,52 @@
 package geotrellis.server.http4s.auth
 
+import geotrellis.server.http4s.Config
+
 import cats._, cats.effect._, cats.implicits._, cats.data._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers.Authorization
 import org.http4s.implicits._
 
+import tsec.authentication._
+import tsec.jws.mac._
+import tsec.jwt._
+import tsec.mac.jca._
+
 import scala.util.Random
 
 import java.time._
 
 object AuthenticationBackends {
-  val successful: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
-    Kleisli(_ => OptionT.liftF(IO(Right(User(100, "Joseph P Morrison")))))
+  // TODO: should be some sort of implicit search for some authInfo type I think
+  def verifyJwt[F[_]: Sync](signingKey: MacSigningKey[HMACSHA256], bearerToken: String): F[Boolean] = {
+    JWTMac.verifyFromStringBool[F, HMACSHA256](bearerToken, signingKey)
+  }
+
+  def fromSigningKey(signingKey: String): Kleisli[OptionT[IO, ?], Request[IO], User] = {
+    val sk = HMACSHA256.unsafeBuildKey(signingKey.toCharArray map { _.toByte })
+    Kleisli(
+      (request: Request[IO]) => {
+        val message: EitherT[IO, Throwable, User] = for {
+          header <- EitherT[IO, Throwable, String](IO(request.headers.get(Authorization).toRight(new Exception("Couldn't find an Authorization header")) map { _.value }))
+          verifiedAndParsed <- EitherT[IO, Throwable, JWTMac[HMACSHA256]](
+            JWTMac.verifyAndParse[IO, HMACSHA256](header, sk).attempt
+          )
+        } yield { User(100, verifiedAndParsed.body.subject.getOrElse("abcdefg")) }
+        message.toOption
+      }
+    )
+  }
+
+  def fromConfig(conf: Config): Kleisli[OptionT[IO, ?], Request[IO], User] = {
+    val authUserO = conf.auth.signingKey map {
+      (signingKey: String) => { fromSigningKey(signingKey) }
+    }
+    authUserO
+  }
+
+  val successful: Kleisli[OptionT[IO, ?], Request[IO], User] =
+    Kleisli(_ => OptionT.liftF(IO(User(1, "Non-authed service"))))
 
   val failed: Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] =
     Kleisli(_ => OptionT.liftF(IO(Left("oh no"))))

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/Rejector.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/Rejector.scala
@@ -1,0 +1,16 @@
+package geotrellis.server.http4s.auth
+
+import org.http4s._
+import org.http4s.dsl.io._
+
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
+trait Rejector {
+  def rejectUnauthorized(authResult: Either[String, User])(resp: => IO[Response[IO]]): IO[Response[IO]] =
+    authResult match {
+      case Right(_) => resp
+      case Left(err) => Forbidden(err)
+    }
+}

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/User.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/User.scala
@@ -1,0 +1,3 @@
+package geotrellis.server.http4s.auth
+
+case class User(id: Long, name: String)

--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/package.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/package.scala
@@ -1,0 +1,3 @@
+package geotrellis.server.http4s.auth
+
+package object auth {}

--- a/http4s/src/main/scala/geotrellis/server/http4s/maml/MamlPersistenceService.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/maml/MamlPersistenceService.scala
@@ -1,6 +1,7 @@
 package geotrellis.server.http4s.maml
 
 import geotrellis.server.core.persistence.MamlStore
+import geotrellis.server.http4s.auth.{User, Rejector}
 import MamlStore.ops._
 
 import com.azavea.maml.ast.Expression
@@ -24,7 +25,7 @@ import java.util.UUID
 import scala.util.Try
 import scala.collection.mutable
 
-class MamlPersistenceService[ExpressionStore: MamlStore](val store: ExpressionStore) extends Http4sDsl[IO] with LazyLogging {
+class MamlPersistenceService[ExpressionStore: MamlStore](val store: ExpressionStore) extends Http4sDsl[IO] with LazyLogging with Rejector {
 
   implicit val expressionDecoder = jsonOf[IO, Expression]
 
@@ -37,26 +38,28 @@ class MamlPersistenceService[ExpressionStore: MamlStore](val store: ExpressionSt
     }
   }
 
-  def routes: HttpService[IO] = HttpService[IO] {
-    case req @ POST -> Root / IdVar(key) =>
+  def routes: AuthedService[Either[String, User], IO] = AuthedService[Either[String, User], IO] {
+    case authedReq @ POST -> Root / IdVar(key) as user => rejectUnauthorized(user) {
       (for {
-        expr <- EitherT(req.as[Expression].attempt)
-        _    <- EitherT.pure[IO, Throwable](logger.info(s"Attempting to store expression ($req.bodyAsText) at key ($key)"))
-        res  <- EitherT(store.putMaml(key, expr).attempt)
-      } yield res).value flatMap {
+         expr <- EitherT(authedReq.req.as[Expression].attempt)
+         _    <- EitherT.pure[IO, Throwable](logger.info(s"Attempting to store expression ($authedReq.req.bodyAsText) at key ($key)"))
+         res  <- EitherT(store.putMaml(key, expr).attempt)
+       } yield res).value flatMap {
         case Right(created) =>
           Created()
         case Left(err) =>
           logger.debug(err.toString, err)
           InternalServerError(err.toString)
       }
+    }
 
-    case req @ GET -> Root / IdVar(key) =>
+    case req @ GET -> Root / IdVar(key) as user => rejectUnauthorized(user) {
       logger.info(s"Attempting to retrieve expression at key ($key)")
       store.getMaml(key) flatMap {
         case Some(expr) => Ok(expr.asJson)
         case None => NotFound()
       }
+    }
   }
 }
 

--- a/http4s/src/main/scala/geotrellis/server/http4s/wcs/WcsService.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/wcs/WcsService.scala
@@ -15,6 +15,7 @@ import io.circe._
 import io.circe.syntax._
 
 import geotrellis.spark.io.AttributeStore
+import geotrellis.server.http4s.auth.{Rejector, User}
 import geotrellis.server.http4s.wcs.params._
 import geotrellis.server.http4s.wcs.ops._
 import geotrellis.spark._
@@ -30,7 +31,7 @@ object WcsService {
   type MetadataCatalog = Map[String, (Seq[Int], Option[TileLayerMetadata[SpatialKey]])]
 }
 
-class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging {
+class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging with Rejector {
 
   def handleError[Result](result: Either[Throwable, Result])(implicit ee: EntityEncoder[IO, Result]) = result match {
     case Right(res) =>
@@ -57,10 +58,10 @@ class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging {
 
   val getCoverage = new GetCoverage(catalog.toString)
 
-  def routes: HttpService[IO] = HttpService[IO] {
-    case req @ GET -> Root =>
-      logger.info(s"Request received: ${req.uri}")
-      WcsParams(req.multiParams) match {
+  def routes: AuthedService[Either[String, User], IO] = AuthedService[Either[String, User], IO] {
+    case authedReq @ GET -> Root as user => rejectUnauthorized(user) {
+      logger.info(s"Request received: ${authedReq.req.uri}")
+      WcsParams(authedReq.req.multiParams) match {
         case Invalid(errors) =>
           val msg = WcsParamsError.generateErrorMessage(errors.toList)
           logger.debug(s"""Error parsing parameters: ${msg}""")
@@ -68,11 +69,11 @@ class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging {
         case Valid(wcsParams) =>
           wcsParams match {
             case p: GetCapabilitiesWcsParams =>
-              val link = s"${req.uri.scheme}://${req.uri.authority}${req.uri.path}?"
+              val link = s"${authedReq.req.uri.scheme}://${authedReq.req.uri.authority}${authedReq.req.uri.path}?"
               logger.info(s"GetCapabilities request arrived at $link")
               Ok(GetCapabilities.build(link, catalogMetadata, p))
             case p: DescribeCoverageWcsParams =>
-              logger.info(s"DescribeCoverage request arrived at ${req.uri}")
+              logger.info(s"DescribeCoverage request arrived at ${authedReq.req.uri}")
               for {
                 getCoverage <- IO { DescribeCoverage.build(catalogMetadata, p) }.attempt
                 result <- handleError(getCoverage)
@@ -81,7 +82,7 @@ class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging {
                 result
               }
             case p: GetCoverageWcsParams =>
-              logger.info(s"GetCoverage request arrived at ${req.uri}")
+              logger.info(s"GetCoverage request arrived at ${authedReq.req.uri}")
               for {
                 getCoverage <- IO { getCoverage.build(catalogMetadata, p) }.attempt
                 result <- handleError(getCoverage)
@@ -91,5 +92,6 @@ class WcsService(catalog: URI) extends Http4sDsl[IO] with LazyLogging {
               }
           }
       }
+    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   val gtServerVer      = "0.1.0"
   val http4sVer        = "0.18.12"
   val scalaVer         = "2.11.12"
+  val tsecV            = "0.0.1-M11"
 
   //val kamonZipkin       = "io.kamon"                      %% "kamon-zipkin"         % "1.0.1"
   val caffeine          = "com.github.ben-manes.caffeine" %  "caffeine"             % "2.3.5"
@@ -40,6 +41,7 @@ object Dependencies {
   val scalatest         = "org.scalatest"                 %%  "scalatest"           % "3.0.4" % "test"
   val simulacrum        = "com.github.mpilquist"          %% "simulacrum"           % "0.12.0"
   val spark             = "org.apache.spark"              %% "spark-core"           % "2.3.0" % "provided"
+  val tsecCommon        = "io.github.jmcardon"            %% "tsec-common"          % tsecV
+  val tsecHttp4s        = "io.github.jmcardon"            %% "tsec-http4s"          % tsecV
   val typesafeLogging   = "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.0"
-
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,43 +1,45 @@
 import sbt._
 
 object Dependencies {
-  val scalaVer         = "2.11.12"
+
+  val circeVer         = "0.10.0-M1"
+  val gtVer            = "2.0.0-RC1"
   val gtServerVer      = "0.1.0"
   val http4sVer        = "0.18.12"
-  val gtVer            = "2.0.0-RC1"
-  val circeVer         = "0.10.0-M1"
+  val scalaVer         = "2.11.12"
 
-  val scalaXml          = "org.scala-lang.modules"        %% "scala-xml"            % "1.1.0"
-  val spark             = "org.apache.spark"              %% "spark-core"           % "2.3.0" % "provided"
-  val hadoop            = "org.apache.hadoop"             %  "hadoop-client"        % "2.8.0" % "provided"
-  val commonsIO         = "commons-io"                    %  "commons-io"           % "2.6"
-  val geotrellisS3      = "org.locationtech.geotrellis"   %% "geotrellis-s3"        % gtVer
-  val geotrellisSpark   = "org.locationtech.geotrellis"   %% "geotrellis-spark"     % gtVer
-  val decline           = "com.monovore"                  %% "decline"              % "0.4.0"
+  //val kamonZipkin       = "io.kamon"                      %% "kamon-zipkin"         % "1.0.1"
+  val caffeine          = "com.github.ben-manes.caffeine" %  "caffeine"             % "2.3.5"
   val cats              = "org.typelevel"                 %% "cats-core"            % "1.1.0"
   val catsEffect        = "org.typelevel"                 %% "cats-effect"          % "0.10.1"
   val circeCore         = "io.circe"                      %% "circe-core"           % circeVer
   val circeGeneric      = "io.circe"                      %% "circe-generic"        % circeVer
-  val circeParser       = "io.circe"                      %% "circe-parser"         % circeVer
   val circeOptics       = "io.circe"                      %% "circe-optics"         % circeVer
-  val typesafeLogging   = "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.0"
-  val logbackClassic    = "ch.qos.logback"                %  "logback-classic"      % "1.2.3"
-  val caffeine          = "com.github.ben-manes.caffeine" %  "caffeine"             % "2.3.5"
+  val circeParser       = "io.circe"                      %% "circe-parser"         % circeVer
+  val commonsIO         = "commons-io"                    %  "commons-io"           % "2.6"
   val concHashMap       = "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2"
-  val scaffeine         = "com.github.blemale"            %% "scaffeine"            % "2.0.0"
-  val http4sBlazeServer = "org.http4s"                    %% "http4s-blaze-server"  % http4sVer
+  val decline           = "com.monovore"                  %% "decline"              % "0.4.0"
+  val geotrellisS3      = "org.locationtech.geotrellis"   %% "geotrellis-s3"        % gtVer
+  val geotrellisSpark   = "org.locationtech.geotrellis"   %% "geotrellis-spark"     % gtVer
+  val hadoop            = "org.apache.hadoop"             %  "hadoop-client"        % "2.8.0" % "provided"
   val http4sBlazeClient = "org.http4s"                    %% "http4s-blaze-client"  % http4sVer
-  val http4sDsl         = "org.http4s"                    %% "http4s-dsl"           % http4sVer
+  val http4sBlazeServer = "org.http4s"                    %% "http4s-blaze-server"  % http4sVer
   val http4sCirce       = "org.http4s"                    %% "http4s-circe"         % http4sVer
+  val http4sDsl         = "org.http4s"                    %% "http4s-dsl"           % http4sVer
   val http4sXml         = "org.http4s"                    %% "http4s-scala-xml"     % http4sVer
-  val simulacrum        = "com.github.mpilquist"          %% "simulacrum"           % "0.12.0"
-  val kindProjector     = "org.spire-math"                %% "kind-projector"       % "0.9.4"
   val kamonCore         = "io.kamon"                      %% "kamon-core"           % "1.1.3"
-  val kamonSysMetrics   = "io.kamon"                      %% "kamon-system-metrics" % "1.0.0"
-  val kamonPrometheus   = "io.kamon"                      %% "kamon-prometheus"     % "1.0.0"
   val kamonHttp4s       = "io.kamon"                      %% "kamon-http4s"         % "1.0.7"
-  //val kamonZipkin       = "io.kamon"                      %% "kamon-zipkin"         % "1.0.1"
-  val pureConfig        = "com.github.pureconfig"         %% "pureconfig"           % "0.9.1"
+  val kamonPrometheus   = "io.kamon"                      %% "kamon-prometheus"     % "1.0.0"
+  val kamonSysMetrics   = "io.kamon"                      %% "kamon-system-metrics" % "1.0.0"
+  val kindProjector     = "org.spire-math"                %% "kind-projector"       % "0.9.4"
+  val logbackClassic    = "ch.qos.logback"                %  "logback-classic"      % "1.2.3"
   val mamlJvm           = "com.azavea"                    %% "maml-jvm"             % "0.0.4-0fbf423"
+  val pureConfig        = "com.github.pureconfig"         %% "pureconfig"           % "0.9.1"
+  val scaffeine         = "com.github.blemale"            %% "scaffeine"            % "2.0.0"
+  val scalaXml          = "org.scala-lang.modules"        %% "scala-xml"            % "1.1.0"
   val scalatest         = "org.scalatest"                 %%  "scalatest"           % "3.0.4" % "test"
+  val simulacrum        = "com.github.mpilquist"          %% "simulacrum"           % "0.12.0"
+  val spark             = "org.apache.spark"              %% "spark-core"           % "2.3.0" % "provided"
+  val typesafeLogging   = "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.0"
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 


### PR DESCRIPTION
Overview
-----

This PR adds (very dumb) authorization to all services -- to make successful request, you have
to include a token with length >= 10. You don't technically need the word token or anything yet.
I wouldn't exactly call this cryptographically secure! But auth works.

### Notes

I think I misunderstood the promises http4s was making about magic 403s. I wound up writing
a [very short custom auth handler](https://github.com/jisantuc/geotrellis-server/blob/feature/js/authorize-requests/http4s/src/main/scala/geotrellis/server/http4s/auth/Rejector.scala) for rejection
handling. I think there's a way to rewrite its types with Kleisli, but I didn't figure it out.

The magic for 403s comes in short-circuiting in for comprehensions -- because we can't finish constructing
the user while decoding the token, the auth logic bails and we get a 403 with the `Left` case :tada:

## Testing

#### Dumb auth (previous strategy)

- set the authentication backend to `fromAuthHeader`
- make some requests without a token of length at least 10
- make some requests with a token of length at least 10
- try out some other authentication strategies if you're feeling up for it

#### Jwt auth

- set a `SIGNING_KEY` environment variable before starting sbt
- apply this diff (well you can't actually `git apply` it but make the changes -- mainly it's that you print a jwt at the beginning of the server's execution):

```diff
diff --git a/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala b/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
index 801f8c4..b80a4ab 100644
--- a/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
+++ b/http4s/src/main/scala/geotrellis/server/http4s/auth/AuthenticationBackends.scala
@@ -22,17 +22,29 @@ object AuthenticationBackends extends LazyLogging {
 
   def fromSigningKey(signingKey: String): Kleisli[OptionT[IO, ?], Request[IO], Either[String, User]] = {
     val sk = HMACSHA256.unsafeBuildKey(signingKey.toCharArray map { _.toByte })
+    val jwtIO = for {
+      claims <- IO(JWTClaims.apply(subject = Some("James Santucci"), expiration = Some(Instant.now.plusSeconds(3600))))
+      jwtString <- JWTMac.buildToString[IO, HMACSHA256](claims, sk)
+      verified <- JWTMac.verifyFromString[IO, HMACSHA256](jwtString, sk)
+    } yield {
+      println(s"A nice jwt for you to use: ${jwtString}")
+    }
+    jwtIO.unsafeRunSync
     Kleisli(
       req => {
         val message: EitherT[IO, String, User] = for {
-          header <- EitherT[IO, String, String](IO(req.headers.get(Authorization).toRight("Couldn't find an Authorization header") map { _.value }))
+          header <- EitherT[IO, String, String](
+            IO(req.headers.get(Authorization).toRight("Couldn't find an Authorization header") map { _.value })
+          )
           verifiedAndParsed <- EitherT[IO, String, JWTMac[HMACSHA256]](
-            JWTMac.verifyAndParse[IO, HMACSHA256](header, sk).attempt map {
+            JWTMac.verifyAndParse[IO, HMACSHA256](header.replace("Bearer ", ""), sk).attempt map {
               case Left(e) => Left(e.getMessage)
               case Right(p) => Right(p)
             }
           )
-        } yield { User(verifiedAndParsed.body.expiration.map( _.getNano ).get, verifiedAndParsed.body.subject.get) }
+        } yield {
+          User(verifiedAndParsed.body.expiration.map( _.getNano ).get, verifiedAndParsed.body.subject.get)
+        }
         OptionT.liftF(message.value)
       }
     )
```

- set the token printed at server startup to some env variable (e.g. `GTS_API_TOKEN`)
- make a request to ping pong with your bearer token set -- `http :9000/ping Authorization:'Bearer $GTS_API_TOKEN`
- change anything in the token and observe that your request fails with a 403

Closes azavea/raster-foundry-platform#378

Closes #16 