### PR TITLE
Use relative paths where possible in client code

### DIFF
--- a/example/src/main/resources/overlay-demo/overlay.js
+++ b/example/src/main/resources/overlay-demo/overlay.js
@@ -1,7 +1,6 @@
 // GLOBAL STATE/MANAGEMENT FUNCS
 var cogForms = [];
 var MAX_COGS = 5;
-var BASE_URL = "http://localhost:9000/"
 var APP_ID;
 var overlayLayer;
 
@@ -138,7 +137,7 @@ function CogForm(uri, band, weight, id) {
 }
 
 function generateTms() {
-  return L.tileLayer(BASE_URL + APP_ID + "/{z}/{x}/{y}.png?dummy=" + guid())
+  return L.tileLayer(APP_ID + "/{z}/{x}/{y}.png?dummy=" + guid())
 }
 
 function initFromJson(json) {
@@ -179,7 +178,7 @@ $(window).ready(function() {
     localStorage.setItem("cog-json", json);
     $.ajax({
       type: "POST",
-      url: BASE_URL + APP_ID,
+      url: APP_ID,
       data: json
     });
 

--- a/example/src/main/scala/geotrellis/server/example/overlay/OverlayDefinition.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/OverlayDefinition.scala
@@ -32,7 +32,7 @@ object OverlayDefinition {
 
       def tmsReification(self: OverlayDefinition, buffer: Int)(implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal] =
         (z: Int, x: Int, y: Int) => {
-          CogUtils.fetch(self.uri.toString, z, x, y).map(_.band(self.band - 1)).map { tile =>
+          CogUtils.fetch(self.uri.toString, z, x, y).map(_.tile.band(self.band - 1)).map { tile =>
             val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
             RasterLit(Raster(tile, extent))
           }

--- a/example/src/main/scala/geotrellis/server/example/overlay/OverlayServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/OverlayServer.scala
@@ -46,7 +46,7 @@ object OverlayServer extends StreamApp[IO] with LazyLogging with Http4sDsl[IO] {
   def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/maml/overlay")))
+      _          <- Stream.eval(IO.pure(logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/")))
       weightedOverlay = new WeightedOverlayService()
       exitCode   <- BlazeBuilder[IO]
         .enableHttp2(true)


### PR DESCRIPTION
Client code won't work in deployment if we don't use relative paths (we have no idea who the host will be). This PR addresses that shortcoming