### PR TITLE
Upgrade cats -> 1.3.1 and cats-effect -> 1.0 and fix fallout

### DIFF
--- a/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
@@ -73,13 +73,13 @@ object MamlHistogram extends LazyLogging {
     implicit reify: MamlExtentReification[Param],
              extended: HasRasterExtents[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ): IO[Interpreted[Histogram[Double]]] =
     for {
       params           <- getParams
       rasterExtents    <- NEL.fromListUnsafe(params.values.toList)
                             .map(_.rasterExtents)
-                            .parSequence
+                            .sequence
                             .map(_.flatten)
       intersection     <- IO { rasterExtents.foldLeft(Option.empty[Extent])({ (mbExtent, re) =>
                             mbExtent match {
@@ -104,7 +104,7 @@ object MamlHistogram extends LazyLogging {
     implicit reify: MamlExtentReification[Param],
              extended: HasRasterExtents[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
 
 
@@ -117,7 +117,7 @@ object MamlHistogram extends LazyLogging {
     implicit reify: MamlExtentReification[Param],
              extended: HasRasterExtents[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ): (Map[String, Param]) => IO[Interpreted[Histogram[Double]]] =
     (paramMap: Map[String, Param]) => {
       apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter, maxCells)
@@ -132,7 +132,7 @@ object MamlHistogram extends LazyLogging {
     implicit reify: MamlExtentReification[Param],
              extended: HasRasterExtents[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ) = curried(RasterVar("identity"), interpreter, maxCells)
 
 }

--- a/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
@@ -79,7 +79,7 @@ object MamlHistogram extends LazyLogging {
       params           <- getParams
       rasterExtents    <- NEL.fromListUnsafe(params.values.toList)
                             .map(_.rasterExtents)
-                            .sequence
+                            .parSequence
                             .map(_.flatten)
       intersection     <- IO { rasterExtents.foldLeft(Option.empty[Extent])({ (mbExtent, re) =>
                             mbExtent match {

--- a/core/src/main/scala/geotrellis/server/core/maml/MamlTms.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/MamlTms.scala
@@ -29,7 +29,7 @@ object MamlTms extends LazyLogging {
   )(
     implicit reify: MamlTmsReification[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ): (Int, Int, Int) => IO[Interpreted[Tile]] = (z: Int, x: Int, y: Int) => {
     for {
       expr             <- getExpression
@@ -37,8 +37,8 @@ object MamlTms extends LazyLogging {
       paramMap         <- getParams
       _                <- IO.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.asJson.noSpaces}"))
       vars             <- IO.pure { Vars.varsWithBuffer(expr) }
-      params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
-                            paramMap(varName).tmsReification(buffer)(t)(z, x, y).map(varName -> _)
+      params           <- vars.toList.traverse { case (varName, (_, buffer)) =>
+                            paramMap(varName).tmsReification(buffer)(contextShift)(z, x, y).map(varName -> _)
                           } map { _.toMap }
       reified          <- IO.pure { Expression.bindParams(expr, params) }
     } yield reified.andThen(interpreter(_)).andThen(_.as[Tile])
@@ -55,8 +55,8 @@ object MamlTms extends LazyLogging {
   )(
     implicit reify: MamlTmsReification[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
-  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)(reify, enc, t)
+             contextShift: ContextShift[IO]
+  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)(reify, enc, contextShift)
 
 
   /** Provide an expression and expect arguments to fulfill its needs */
@@ -66,10 +66,10 @@ object MamlTms extends LazyLogging {
   )(
     implicit reify: MamlTmsReification[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ): (Map[String, Param], Int, Int, Int) => IO[Interpreted[Tile]] =
     (paramMap: Map[String, Param], z: Int, x: Int, y: Int) => {
-      apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter)(reify, enc, t)(z, x, y)
+      apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter)(reify, enc, contextShift)(z, x, y)
     }
 
 
@@ -79,7 +79,7 @@ object MamlTms extends LazyLogging {
   )(
     implicit reify: MamlTmsReification[Param],
              enc: Encoder[Param],
-             t: Timer[IO]
+             contextShift: ContextShift[IO]
   ) = curried(RasterVar("identity"), interpreter)
 
 }

--- a/core/src/main/scala/geotrellis/server/core/maml/instances/CogNode.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/instances/CogNode.scala
@@ -52,7 +52,7 @@ object CogNode {
         .map(_.band(self.band))
       (fetch(x - 1, y + 1), fetch(x, y + 1), fetch(x + 1, y + 1),
        fetch(x - 1, y),     fetch(x, y),     fetch(x + 1, y),
-       fetch(x - 1, y - 1), fetch(x, y - 1), fetch(x + 1, y - 1)).mapN { (tl, tm, tr, ml, mm, mr, bl, bm, br) =>
+       fetch(x - 1, y - 1), fetch(x, y - 1), fetch(x + 1, y - 1)).parMapN { (tl, tm, tr, ml, mm, mr, bl, bm, br) =>
         val tile = TileWithNeighbors(mm, Some(NeighboringTiles(tl, tm, tr, ml, mr,bl, bm, br))).withBuffer(buffer)
         val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
         RasterLit(Raster(tile, extent))

--- a/core/src/main/scala/geotrellis/server/core/maml/instances/CogNode.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/instances/CogNode.scala
@@ -33,11 +33,11 @@ object CogNode {
   implicit val cogNodeDecoder: Decoder[CogNode] = deriveDecoder[CogNode]
 
   implicit val cogNodeRasterExtents: HasRasterExtents[CogNode] = new HasRasterExtents[CogNode] {
-    def rasterExtents(self: CogNode)(implicit t: Timer[IO]): IO[NEL[RasterExtent]] =
+    def rasterExtents(self: CogNode)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
       CogUtils.getTiff(self.uri.toString).map { tiff =>
         NEL(tiff.rasterExtent, tiff.overviews.map(_.rasterExtent))
       }
-    def crs(self: CogNode)(implicit t: Timer[IO]): IO[CRS] =
+    def crs(self: CogNode)(implicit contextShift: ContextShift[IO]): IO[CRS] =
       CogUtils.getTiff(self.uri.toString).map { tiff =>
         tiff.crs
       }
@@ -45,14 +45,14 @@ object CogNode {
 
   implicit val cogNodeTmsReification: MamlTmsReification[CogNode] = new MamlTmsReification[CogNode] {
     def kind(self: CogNode): MamlKind = MamlKind.Tile
-    def tmsReification(self: CogNode, buffer: Int)(implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
+    def tmsReification(self: CogNode, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
       def fetch(xCoord: Int, yCoord: Int) =
         CogUtils.fetch(self.uri.toString, z, xCoord, yCoord)
         .map(_.tile)
         .map(_.band(self.band))
       (fetch(x - 1, y + 1), fetch(x, y + 1), fetch(x + 1, y + 1),
        fetch(x - 1, y),     fetch(x, y),     fetch(x + 1, y),
-       fetch(x - 1, y - 1), fetch(x, y - 1), fetch(x + 1, y - 1)).parMapN { (tl, tm, tr, ml, mm, mr, bl, bm, br) =>
+       fetch(x - 1, y - 1), fetch(x, y - 1), fetch(x + 1, y - 1)).mapN { (tl, tm, tr, ml, mm, mr, bl, bm, br) =>
         val tile = TileWithNeighbors(mm, Some(NeighboringTiles(tl, tm, tr, ml, mr,bl, bm, br))).withBuffer(buffer)
         val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
         RasterLit(Raster(tile, extent))
@@ -62,7 +62,7 @@ object CogNode {
 
   implicit val cogNodeExtentReification: MamlExtentReification[CogNode] = new MamlExtentReification[CogNode] {
     def kind(self: CogNode): MamlKind = MamlKind.Tile
-    def extentReification(self: CogNode)(implicit t: Timer[IO]): (Extent, CellSize) => IO[Literal] = (extent: Extent, cs: CellSize) => {
+    def extentReification(self: CogNode)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal] = (extent: Extent, cs: CellSize) => {
       CogUtils.getTiff(self.uri.toString)
         .map { CogUtils.cropGeoTiffToTile(_, extent, cs, self.band) }
         .map { RasterLit(_) }

--- a/core/src/main/scala/geotrellis/server/core/maml/metadata/HasRasterExtent.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/metadata/HasRasterExtent.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 
 @typeclass trait HasRasterExtents[A] {
-  @op("rasterExtents") def rasterExtents(self: A)(implicit t: Timer[IO]): IO[NEL[RasterExtent]]
-  @op("crs") def crs(self: A)(implicit t: Timer[IO]): IO[CRS]
+  @op("rasterExtents") def rasterExtents(self: A)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]]
+  @op("crs") def crs(self: A)(implicit contextShift: ContextShift[IO]): IO[CRS]
 }
 

--- a/core/src/main/scala/geotrellis/server/core/maml/reification/MamlExtentReification.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/reification/MamlExtentReification.scala
@@ -13,6 +13,6 @@ import java.util.UUID
 
 @typeclass trait MamlExtentReification[A] {
   @op("kind") def kind(self: A): MamlKind
-  @op("extentReification") def extentReification(self: A)(implicit t: Timer[IO]): (Extent, CellSize) => IO[Literal]
+  @op("extentReification") def extentReification(self: A)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal]
 }
 

--- a/core/src/main/scala/geotrellis/server/core/maml/reification/MamlTmsReification.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/reification/MamlTmsReification.scala
@@ -12,6 +12,6 @@ import java.util.UUID
 
 @typeclass trait MamlTmsReification[A] {
   @op("kind") def kind(self: A): MamlKind
-  @op("tmsReification") def tmsReification(self: A, buffer: Int)(implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal]
+  @op("tmsReification") def tmsReification(self: A, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal]
 }
 

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviMamlServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviMamlServer.scala
@@ -30,6 +30,8 @@ import java.util.UUID
 
 object NdviMamlServer extends StreamApp[IO] with LazyLogging with Http4sDsl[IO] {
 
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+
   private val corsConfig = CORSConfig(
     anyOrigin = true,
     anyMethod = false,

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviMamlService.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviMamlService.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable
 
 class ExampleNdviMamlService[Param](
   interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
-)(implicit t: Timer[IO],
+)(implicit contextShift: ContextShift[IO],
            enc: Encoder[Param],
            dec: Decoder[Param],
            mr: MamlTmsReification[Param]) extends Http4sDsl[IO] with LazyLogging {

--- a/example/src/main/scala/geotrellis/server/example/overlay/OverlayDefinition.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/OverlayDefinition.scala
@@ -30,7 +30,7 @@ object OverlayDefinition {
     new MamlTmsReification[OverlayDefinition] {
       def kind(self: OverlayDefinition): MamlKind = MamlKind.Tile
 
-      def tmsReification(self: OverlayDefinition, buffer: Int)(implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal] =
+      def tmsReification(self: OverlayDefinition, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] =
         (z: Int, x: Int, y: Int) => {
           CogUtils.fetch(self.uri.toString, z, x, y).map(_.tile.band(self.band - 1)).map { tile =>
             val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
@@ -43,7 +43,7 @@ object OverlayDefinition {
     new MamlExtentReification[OverlayDefinition] {
       def kind(self: OverlayDefinition): MamlKind = MamlKind.Tile
 
-      def extentReification(self: OverlayDefinition)(implicit t: Timer[IO]): (Extent, CellSize) => IO[Literal] =
+      def extentReification(self: OverlayDefinition)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal] =
         (extent: Extent, cs: CellSize) => {
           CogUtils.getTiff(self.uri.toString)
             .map { CogUtils.cropGeoTiffToTile(_, extent, cs, self.band - 1) }
@@ -52,11 +52,11 @@ object OverlayDefinition {
     }
 
   implicit val overlayDefinitionRasterExtents: HasRasterExtents[OverlayDefinition] = new HasRasterExtents[OverlayDefinition] {
-    def rasterExtents(self: OverlayDefinition)(implicit t: Timer[IO]): IO[NEL[RasterExtent]] =
+    def rasterExtents(self: OverlayDefinition)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
       CogUtils.getTiff(self.uri.toString).map { tiff =>
         NEL(tiff.rasterExtent, tiff.overviews.map(_.rasterExtent))
       }
-    def crs(self: OverlayDefinition)(implicit t: Timer[IO]): IO[CRS] =
+    def crs(self: OverlayDefinition)(implicit contextShift: ContextShift[IO]): IO[CRS] =
       CogUtils.getTiff(self.uri.toString).map { tiff =>
         tiff.crs
       }

--- a/example/src/main/scala/geotrellis/server/example/overlay/OverlayServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/OverlayServer.scala
@@ -31,6 +31,8 @@ import java.util.UUID
 
 object OverlayServer extends StreamApp[IO] with LazyLogging with Http4sDsl[IO] {
 
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+
   private val corsConfig = CORSConfig(
     anyOrigin = true,
     anyMethod = false,

--- a/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayService.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayService.scala
@@ -36,7 +36,7 @@ import scala.collection.mutable
 
 class WeightedOverlayService(
   interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
-)(implicit t: Timer[IO]) extends Http4sDsl[IO] with LazyLogging {
+)(implicit contextShift: ContextShift[IO]) extends Http4sDsl[IO] with LazyLogging {
 
   // Unapply to handle UUIDs on path
   object IdVar {

--- a/example/src/main/scala/geotrellis/server/example/persistence/MamlPersistenceServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/MamlPersistenceServer.scala
@@ -31,6 +31,8 @@ import java.util.UUID
 
 object MamlPersistenceServer extends StreamApp[IO] with LazyLogging with Http4sDsl[IO] {
 
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+
   private val corsConfig = CORSConfig(
     anyOrigin = true,
     anyMethod = false,

--- a/example/src/main/scala/geotrellis/server/example/persistence/MamlPersistenceService.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/MamlPersistenceService.scala
@@ -31,7 +31,7 @@ import scala.collection.mutable
 
 class MamlPersistenceService[Store, Param](
   val store: Store
-)(implicit t: Timer[IO],
+)(implicit contextShift: ContextShift[IO],
            ms: MamlStore[Store],
            pd: Decoder[Param],
            mr: MamlTmsReification[Param]) extends Http4sDsl[IO] with LazyLogging {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val circeVer         = "0.10.0-M1"
+  val circeVer         = "0.10.0"
   val gtVer            = "2.0.0"
   val gtServerVer      = "0.1.0"
   val http4sVer        = "0.18.12"
@@ -11,8 +11,8 @@ object Dependencies {
 
   //val kamonZipkin       = "io.kamon"                      %% "kamon-zipkin"         % "1.0.1"
   val caffeine          = "com.github.ben-manes.caffeine" %  "caffeine"             % "2.3.5"
-  val cats              = "org.typelevel"                 %% "cats-core"            % "1.1.0"
-  val catsEffect        = "org.typelevel"                 %% "cats-effect"          % "0.10.1"
+  val cats              = "org.typelevel"                 %% "cats-core"            % "1.3.1"
+  val catsEffect        = "org.typelevel"                 %% "cats-effect"          % "1.0.0"
   val circeCore         = "io.circe"                      %% "circe-core"           % circeVer
   val circeShapes       = "io.circe"                      %% "circe-shapes"         % circeVer
   val circeGeneric      = "io.circe"                      %% "circe-generic"        % circeVer


### PR DESCRIPTION
Overview
-----

This PR upgrades cats and cats-effect to current versions. Main changes are:

- `parFoo` methods were replaced with `Foo`, since I'm not sure right now how to provide evidence for `Parallel[IO, F]`
- `implicit t: Timer[IO]` -> `implicit contextShift: ContextShift[IO]`, since the latter is what's required for evidence in `cats-effect` 1.0

Testing
-----

- compilation is fine
- run some examples

Closes #30 