### PR TITLE
Simplify helper methods

### DIFF
--- a/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/core/maml/MamlHistogram.scala
@@ -126,14 +126,17 @@ object MamlHistogram extends LazyLogging {
 
   /** The identity endpoint (for simple display of raster) */
   def identity[Param](
-    interpreter: BufferingInterpreter,
+    param: Param,
     maxCells: Int
   )(
     implicit reify: MamlExtentReification[Param],
              extended: HasRasterExtents[Param],
              enc: Encoder[Param],
              contextShift: ContextShift[IO]
-  ) = curried(RasterVar("identity"), interpreter, maxCells)
+  ) = {
+    val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT, maxCells)
+    eval(Map("identity" -> param))
+  }
 
 }
 


### PR DESCRIPTION
The biggest win here is the fact that `identity` calls should no longer require parameter maps