### PR TITLE
Move to http4s 0.19 fs2 1.0 and cats 1.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,31 +2,34 @@ version: '3'
 services:
   overlay-example:
     image: quay.io/geotrellis/server:latest
+    command: /bin/sh -c "java -cp /opt/geotrellis-server-example.jar geotrellis.server.example.overlay.WeightedOverlayServer"
     ports:
       - "9000:9000"
     volumes:
       - $HOME/.aws:/root/.aws
     build:
       context: docker
-      dockerfile: overlay.dockerfile
+      dockerfile: examples.dockerfile
   persistence-example:
     image: quay.io/geotrellis/server:latest
+    command: /bin/sh -c "java -cp /opt/geotrellis-server-example.jar geotrellis.server.example.persistence.PersistenceServer"
     ports:
       - "9000:9000"
     volumes:
       - $HOME/.aws:/root/.aws
     build:
       context: docker
-      dockerfile: persistence.dockerfile
+      dockerfile: examples.dockerfile
   ndvi-example:
     image: quay.io/geotrellis/server:latest
+    command: /bin/sh -c "java -cp /opt/geotrellis-server-example.jar geotrellis.server.example.ndvi.NdviServer"
     ports:
       - "9000:9000"
     volumes:
       - $HOME/.aws:/root/.aws
     build:
       context: docker
-      dockerfile: ndvi.dockerfile
+      dockerfile: examples.dockerfile
 
   server-microsite:
     image: quay.io/geotrellis/server-microsite:latest

--- a/docker/examples.dockerfile
+++ b/docker/examples.dockerfile
@@ -3,4 +3,3 @@ FROM openjdk:8-jre-alpine
 COPY geotrellis-server-example.jar /opt/geotrellis-server-example.jar
 WORKDIR /opt
 
-ENTRYPOINT ["java", "-cp", "/opt/geotrellis-server-example.jar", "geotrellis.server.example.ndvi.NdviServer"]

--- a/docker/overlay.dockerfile
+++ b/docker/overlay.dockerfile
@@ -1,6 +1,0 @@
-FROM openjdk:8-jre-alpine
-
-COPY geotrellis-server-example.jar /opt/geotrellis-server-example.jar
-WORKDIR /opt
-
-ENTRYPOINT ["java", "-cp", "/opt/geotrellis-server-example.jar", "geotrellis.server.example.overlay.WeightedOverlayServer"]

--- a/docker/persistence.dockerfile
+++ b/docker/persistence.dockerfile
@@ -1,6 +1,0 @@
-FROM openjdk:8-jre-alpine
-
-COPY geotrellis-server-example.jar /opt/geotrellis-server-example.jar
-WORKDIR /opt
-
-ENTRYPOINT ["java", "-cp", "/opt/geotrellis-server-example.jar", "geotrellis.server.example.persistence.PersistenceServer"]

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
@@ -4,32 +4,29 @@ import geotrellis.server.core.conf.LoadConf
 import geotrellis.server.example.ExampleConf
 import geotrellis.server.core.maml._
 
-import com.azavea.maml.ast.Expression
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
 import cats.data._
 import cats.effect._
+import cats.implicits._
 import io.circe._
 import io.circe.syntax._
 import fs2._
+import com.typesafe.scalalogging.LazyLogging
 import org.http4s.circe._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
-import org.http4s.server.blaze.BlazeBuilder
-import org.http4s.server.HttpMiddleware
-import org.http4s.server.middleware.{GZip, CORS, CORSConfig}
-import org.http4s.headers.{Location, `Content-Type`}
-import org.http4s.client.Client
-import com.typesafe.scalalogging.LazyLogging
+import org.http4s.server._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.middleware.{CORS, CORSConfig}
+import org.http4s.syntax.kleisli._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.collection.mutable
-import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
 
 
-object NdviServer extends LazyLogging with Http4sDsl[IO] {
-
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+object NdviServer extends LazyLogging with IOApp {
 
   private val corsConfig = CORSConfig(
     anyOrigin = true,
@@ -39,21 +36,25 @@ object NdviServer extends LazyLogging with Http4sDsl[IO] {
     maxAge = 1.day.toSeconds
   )
 
-  private val commonMiddleware: HttpMiddleware[IO] = { (routes: HttpService[IO]) =>
+  private val commonMiddleware: HttpMiddleware[IO] = { (routes: HttpRoutes[IO]) =>
     CORS(routes)
   }
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
+  val stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO.pure(logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/maml/overlay")))
       mamlNdviRendering = new NdviService[CogNode]()
-      exitCode   <- BlazeBuilder[IO]
+      exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)
-        .mountService(commonMiddleware(mamlNdviRendering.routes), "/maml/ndvi")
+        .withHttpApp(Router("/" -> commonMiddleware(mamlNdviRendering.routes)).orNotFound)
         .serve
     } yield exitCode
   }
+
+  /** The 'main' method for a cats-effect IOApp */
+  override def run(args: List[String]): IO[ExitCode] =
+    stream.compile.drain.as(ExitCode.Success)
 }
 

--- a/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
@@ -4,33 +4,23 @@ import geotrellis.server.example.ExampleConf
 import geotrellis.server.core.conf.LoadConf
 import geotrellis.server.core.maml._
 
-import com.azavea.maml.ast.Expression
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
 import cats.data._
 import cats.effect._
-import io.circe._
-import io.circe.syntax._
+import cats.implicits._
 import fs2._
-import org.http4s.circe._
-import org.http4s._
-import org.http4s.dsl.Http4sDsl
-import org.http4s.client.blaze.Http1Client
-import org.http4s.server.blaze.BlazeBuilder
-import org.http4s.server.HttpMiddleware
-import org.http4s.server.middleware.{GZip, CORS, CORSConfig}
-import org.http4s.headers.{Location, `Content-Type`}
-import org.http4s.client.Client
 import com.typesafe.scalalogging.LazyLogging
+import org.http4s._
+import org.http4s.server._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.middleware.{CORS, CORSConfig}
+import org.http4s.syntax.kleisli._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.collection.mutable
-import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
 
 
-object WeightedOverlayServer extends LazyLogging with Http4sDsl[IO] {
 
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+object WeightedOverlayServer extends LazyLogging with IOApp {
 
   private val corsConfig = CORSConfig(
     anyOrigin = true,
@@ -40,21 +30,25 @@ object WeightedOverlayServer extends LazyLogging with Http4sDsl[IO] {
     maxAge = 1.day.toSeconds
   )
 
-  private val commonMiddleware: HttpMiddleware[IO] = { (routes: HttpService[IO]) =>
+  private val commonMiddleware: HttpMiddleware[IO] = { (routes: HttpRoutes[IO]) =>
     CORS(routes)
   }
 
-  def stream(args: List[String], requestShutdown: IO[Unit]): Stream[IO, ExitCode] = {
+  def stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO.pure(logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/")))
-      weightedOverlay = new WeightedOverlayService()
-      exitCode   <- BlazeBuilder[IO]
+      overlayService = new WeightedOverlayService()
+      exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)
-        .mountService(commonMiddleware(weightedOverlay.routes), "/")
+        .withHttpApp(Router("/" -> commonMiddleware(overlayService.routes)).orNotFound)
         .serve
     } yield exitCode
   }
+
+  /** The 'main' method for a cats-effect IOApp */
+  override def run(args: List[String]): IO[ExitCode] =
+    stream.compile.drain.as(ExitCode.Success)
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,13 +4,13 @@ object Dependencies {
 
   val circeVer         = "0.10.0"
   val gtVer            = "2.0.0"
-  val http4sVer        = "0.19.0-M3"
+  val http4sVer        = "0.19.0"
   val scalaVer         = "2.11.12"
   val tsecV            = "0.0.1-M11"
 
   //val kamonZipkin       = "io.kamon"                      %% "kamon-zipkin"         % "1.0.1"
   val caffeine          = "com.github.ben-manes.caffeine" %  "caffeine"             % "2.3.5"
-  val cats              = "org.typelevel"                 %% "cats-core"            % "1.3.1"
+  val cats              = "org.typelevel"                 %% "cats-core"            % "1.4.0"
   val catsEffect        = "org.typelevel"                 %% "cats-effect"          % "1.0.0"
   val circeCore         = "io.circe"                      %% "circe-core"           % circeVer
   val circeShapes       = "io.circe"                      %% "circe-shapes"         % circeVer


### PR DESCRIPTION
This PR brings `fs2` up to the first major version, `cats` to the next minor version, and `http4s` to the 0.19 build which plays nicely with the growing cats ecosystem.
It also simplifies the demo setup by removing unnecessary dockerfiles and using more `docker-compose` features