### PR TITLE
Bump to version 0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ responsive layers whose transformations can be described in MAML
 ### Including Geotrellis Server
 
 Current version:
- - 0.0.5
+ - 0.0.6
 
 Add the geotrellis-server dependency by declaring it within your
 project's `build.sbt`:
-`libraryDependencies += "com.azavea" %% "geotrellis-server-core" % "0.0.5"`
+`libraryDependencies += "com.azavea" %% "geotrellis-server-core" % "0.0.6"`
 
 
 ### High level concepts

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion in ThisBuild := scalaVer
 
 lazy val commonSettings = Seq(
   organization := "com.azavea",
-  version := "0.0.5",
+  version := "0.0.6",
   licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   cancelable in Global := true,
   scalaVersion := scalaVer,


### PR DESCRIPTION
This PR increments the version and fixes a histogram generation bug related to sample extent generation sometimes failing