### PR TITLE
Use simple, trusted extent sampling

### DIFF
--- a/core/src/test/scala/geotrellis/server/HistogramHeuristicsTest.scala
+++ b/core/src/test/scala/geotrellis/server/HistogramHeuristicsTest.scala
@@ -21,10 +21,17 @@ class HistogramHeuristicsTest extends FunSuite with Matchers {
       val randomYMaxOffset = random.nextInt(1000).toDouble + 1
 
       val uberExtent = Extent(randomXMin, randomYMin, randomXMin + randomXMaxOffset, randomYMin + randomYMaxOffset)
-      val cs = CellSize(random.nextDouble, random.nextDouble)
+      val cs = CellSize(10 * random.nextDouble, 10 * random.nextDouble)
       val maxCells = 4000
       val sampleExtent = LayerHistogram.sampleRasterExtent(uberExtent, cs, maxCells)
-      assert(uberExtent.envelope.contains(sampleExtent), "overall extent must contain sample extent")
+      assert(uberExtent.contains(sampleExtent) || uberExtent.covers(sampleExtent), "overall extent must contain sample extent")
     }
+  }
+
+  test("extent sampling for big cellsizes") {
+    val e = Extent(504885.0, 3872385.0, 733815.0, 4105515.0)
+    val cs = CellSize(479.937106918239, 479.69135802469134)
+    val sampleExtent = LayerHistogram.sampleRasterExtent(e, cs, 255)
+    assert(e.contains(sampleExtent), "overall extent must contain sample extent")
   }
 }


### PR DESCRIPTION
The prior strategy was clever, but had sharp edges (for certain cellsizes, it could generate extents outside the area to be sampled and it was susceptible to this being caused specifically by floating point arithmetic). As such, a simpler (far easier to reason about) strategy has been selected that doesn't run into the above problems.