### PR TITLE
Reinstate a runnable WCS server

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   val circeVer         = "0.10.0"
-  val gtVer            = "2.0.0"
+  val gtVer            = "2.1.0"
   val http4sVer        = "0.19.0"
   val scalaVer         = "2.11.12"
   val tsecV            = "0.0.1-M11"

--- a/wcs/src/main/scala/geotrellis/server/wcs/ops/GetCapabilities.scala
+++ b/wcs/src/main/scala/geotrellis/server/wcs/ops/GetCapabilities.scala
@@ -36,7 +36,7 @@ object GetCapabilities extends LazyLogging {
 
   private def addLayers100(metadata: MetadataCatalog) = {
     metadata.map { case (identifier, (zooms, maybeMetadata)) => {
-      logger.info(s"Adding v1.0.0 tag for $identifier")
+      //logger.info(s"Adding v1.0.0 tag for $identifier")
       maybeMetadata match {
         case Some(metadata) =>
           val crs = metadata.crs
@@ -53,7 +53,7 @@ object GetCapabilities extends LazyLogging {
 
   private def addLayers110(metadata: MetadataCatalog) = {
     metadata.map { case (identifier, (zooms, maybeMetadata)) => {
-      logger.info(s"Adding v1.1.0 tag for $identifier")
+      //logger.info(s"Adding v1.1.0 tag for $identifier")
       maybeMetadata match {
         case Some(metadata) =>
           val crs = metadata.crs

--- a/wcs/src/test/resources/application.conf
+++ b/wcs/src/test/resources/application.conf
@@ -1,0 +1,16 @@
+http {
+    "interface": "0.0.0.0"
+    "interface": ${?HTTP_INTERFACE}
+    "port": 5678
+    "port": ${?HTTP_PORT}
+}
+
+auth {
+    "signing-key": "REPLACEME"
+    "signing-key": ${?SIGNING_KEY}
+}
+
+settings {
+    "catalog": "s3://azavea-datahub/catalog"
+    "catalog": ${?WCS_CATALOG}
+}

--- a/wcs/src/test/scala/geotrellis/server/LoadConf.scala
+++ b/wcs/src/test/scala/geotrellis/server/LoadConf.scala
@@ -1,0 +1,24 @@
+package geotrellis.server.example
+
+import cats.effect.IO
+import com.typesafe.config.ConfigFactory
+import pureconfig.error.ConfigReaderException
+
+import java.net.URI
+import scala.reflect.ClassTag
+
+
+object LoadConf {
+
+  import pureconfig._
+
+  def apply(configFile: String = "application.conf") = new {
+    def as[Conf: ClassTag: ConfigReader]: IO[Conf] =
+      IO {
+        loadConfig[Conf](ConfigFactory.load(configFile))
+      }.flatMap {
+        case Left(e) => IO.raiseError[Conf](new ConfigReaderException[Conf](e))
+        case Right(config) => IO.pure(config)
+      }
+  }
+}

--- a/wcs/src/test/scala/geotrellis/server/WcsConf.scala
+++ b/wcs/src/test/scala/geotrellis/server/WcsConf.scala
@@ -1,0 +1,11 @@
+package geotrellis.server.wcs
+
+import java.net.URI
+
+case class WcsConf(http: WcsConf.Http, auth: WcsConf.Auth, settings: WcsConf.Settings)
+
+object WcsConf {
+  case class Http(interface: String, port: Int)
+  case class Auth(signingKey: String)
+  case class Settings(catalog: String)
+}

--- a/wcs/src/test/scala/geotrellis/server/WcsServer.scala
+++ b/wcs/src/test/scala/geotrellis/server/WcsServer.scala
@@ -1,0 +1,64 @@
+package geotrellis.server.wcs
+
+import geotrellis.server._
+import geotrellis.server.example._
+
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import io.circe._
+import io.circe.syntax._
+import fs2._
+import com.typesafe.scalalogging.LazyLogging
+import org.http4s.circe._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server._
+import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.server.middleware.{CORS, CORSConfig}
+import org.http4s.syntax.kleisli._
+
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object NlcdServer extends LazyLogging with IOApp {
+
+  private val corsConfig = CORSConfig(
+    anyOrigin = true,
+    anyMethod = false,
+    allowedMethods = Some(Set("GET")),
+    allowCredentials = true,
+    maxAge = 1.day.toSeconds
+  )
+
+  private val commonMiddleware: HttpMiddleware[IO] = { (routes: HttpRoutes[IO]) =>
+    CORS(routes)
+  }
+
+  val ip = {
+    val socket = new java.net.DatagramSocket()
+    socket.connect(java.net.InetAddress.getByName("8.8.8.8"), 10002)
+    val result = socket.getLocalAddress.getHostAddress
+    socket.close
+    result
+  }
+
+  val stream: Stream[IO, ExitCode] = {
+    for {
+      conf       <- Stream.eval(LoadConf().as[WcsConf])
+      _          <- Stream.eval(IO.pure(logger.info(s"Initializing WCS service at ${conf.http.interface}:${conf.http.port}")))
+      wcsRendering = new WcsService(new java.net.URI(conf.settings.catalog), ip, conf.http.port)
+      exitCode   <- BlazeServerBuilder[IO]
+        .enableHttp2(true)
+        .bindHttp(conf.http.port, conf.http.interface)
+        .withHttpApp(Router("/" -> commonMiddleware(wcsRendering.routes)).orNotFound)
+        .serve
+    } yield exitCode
+  }
+
+  /** The 'main' method for a cats-effect IOApp */
+  override def run(args: List[String]): IO[ExitCode] =
+    stream.compile.drain.as(ExitCode.Success)
+}

--- a/wcs/src/test/scala/geotrellis/server/WcsServer.scala
+++ b/wcs/src/test/scala/geotrellis/server/WcsServer.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object NlcdServer extends LazyLogging with IOApp {
+object WcsServer extends LazyLogging with IOApp {
 
   private val corsConfig = CORSConfig(
     anyOrigin = true,


### PR DESCRIPTION
In a previous life, the WCS server was a standalone application.  After the transition to http4s, this capability was lost.  This PR restores this feature by adding a `WcsServer` object to the test module.  The WCS server may be run from the sbt console wcs project via the `test:run` command.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>