### PR TITLE
Microbench NDVI using raster sources

### DIFF
--- a/bench/src/main/resources/logback.xml
+++ b/bench/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%thread] %-5level - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="FATAL">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/bench/src/main/scala/geotrellis/server/TmsReificationBench.scala
+++ b/bench/src/main/scala/geotrellis/server/TmsReificationBench.scala
@@ -10,6 +10,7 @@ import com.azavea.maml.util.Square
 import com.azavea.maml.eval.BufferingInterpreter
 import cats.effect._
 import org.openjdk.jmh.annotations._
+import org.gdal.gdal.gdalJNI
 
 import scala.concurrent.ExecutionContext
 import java.net.URI
@@ -18,6 +19,9 @@ import java.net.URI
 @BenchmarkMode(Array(Mode.AverageTime))
 @State(Scope.Thread)
 class TmsReificationBench {
+
+  // gdal performance will be obscured by the caching it attempts
+  gdalJNI.SetConfigOption("GDAL_CACHEMAX", "0")
 
   implicit var contextShift = IO.contextShift(ExecutionContext.global)
 

--- a/bench/src/main/scala/geotrellis/server/TmsReificationBench.scala
+++ b/bench/src/main/scala/geotrellis/server/TmsReificationBench.scala
@@ -1,0 +1,61 @@
+package geotrellis.server
+
+import geotrellis.server.vlm.geotiff._
+import geotrellis.server.vlm.gdal._
+
+import geotrellis.raster.MultibandTile
+import com.azavea.maml.ast._
+import com.azavea.maml.error._
+import com.azavea.maml.util.Square
+import com.azavea.maml.eval.BufferingInterpreter
+import cats.effect._
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.ExecutionContext
+import java.net.URI
+
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@State(Scope.Thread)
+class TmsReificationBench {
+
+  implicit var contextShift = IO.contextShift(ExecutionContext.global)
+
+  // NDVI
+  val ast =
+    Division(List(
+      Subtraction(List(
+        RasterVar("red"),
+        RasterVar("nir"))),
+      Addition(List(
+        RasterVar("red"),
+        RasterVar("nir"))
+      ))
+    )
+
+  // red, green, NIR bands which should have data for z/x/y 9/454/200
+  val geotiffVars = Map(
+    "red" -> GeoTiffNode(new URI("https://s3.amazonaws.com/geotrellis-test/daunnc/r-g-nir-with-ovrs.tif"), 0, None),
+    "nir" -> GeoTiffNode(new URI("https://s3.amazonaws.com/geotrellis-test/daunnc/r-g-nir-with-ovrs.tif"), 2, None)
+  )
+  val gdalVars = Map(
+    "red" -> GDALNode(new URI("https://s3.amazonaws.com/geotrellis-test/daunnc/r-g-nir-with-ovrs.tif"), 0, None),
+    "nir" -> GDALNode(new URI("https://s3.amazonaws.com/geotrellis-test/daunnc/r-g-nir-with-ovrs.tif"), 2, None)
+  )
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {}
+
+  @Benchmark
+  def geotiffLayerTms: Interpreted[MultibandTile] = {
+    val eval = LayerTms(IO(ast), IO(geotiffVars), BufferingInterpreter.DEFAULT)
+    eval(9, 454, 200).unsafeRunSync
+  }
+
+  @Benchmark
+  def gdalLayerTms: Interpreted[MultibandTile] = {
+    val eval = LayerTms(IO(ast), IO(gdalVars), BufferingInterpreter.DEFAULT)
+    eval(9, 454, 200).unsafeRunSync
+  }
+}
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7")
 


### PR DESCRIPTION
JMH benchmarks are added here to estimate the performance of the GeoTrellis and GDAL backed tile resolution for MAML evaluation. The numbers right now look *highly* suspect for a couple of reasons:
1. GDAL is consistently unbelievably fast. Caching of results is very likely causing us to see numbers that are too good to be true
2. GeoTrellis performance is... not acceptable. ~200seconds for resolving a portion of a tiff and evaluating NDVI over it