### PR TITLE
Move version number to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val commonSettings = Seq(
   cancelable in Global := true,
   scalaVersion := scalaVer,
   crossScalaVersions := crossScalaVer,
+  version := "0.0.11",
   scalacOptions := Seq(
     "-deprecation",
     "-unchecked",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.0.9"


### PR DESCRIPTION
Not super obvious where the version number lives; moving it to build.sbt