### PR TITLE
Remove typeclass requirements and required typeclasses where possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
   cancelable in Global := true,
   scalaVersion := scalaVer,
   crossScalaVersions := crossScalaVer,
-  version := "0.0.11",
+  version := "0.0.12",
   scalacOptions := Seq(
     "-deprecation",
     "-unchecked",

--- a/core/src/main/scala/geotrellis/server/HasRasterExtents.scala
+++ b/core/src/main/scala/geotrellis/server/HasRasterExtents.scala
@@ -10,6 +10,5 @@ import simulacrum._
 
 @typeclass trait HasRasterExtents[A] {
   @op("rasterExtents") def rasterExtents(self: A)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]]
-  @op("crs") def crs(self: A)(implicit contextShift: ContextShift[IO]): IO[CRS]
 }
 

--- a/core/src/main/scala/geotrellis/server/LayerExtent.scala
+++ b/core/src/main/scala/geotrellis/server/LayerExtent.scala
@@ -27,14 +27,13 @@ object LayerExtent extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Extent, CellSize) => IO[Interpreted[MultibandTile]]  = (extent: Extent, cs: CellSize) =>  {
     for {
       expr             <- getExpression
-      _                <- IO.pure(logger.info(s"Retrieved MAML AST for extent ($extent) and cellsize ($cs): ${expr.asJson.noSpaces}"))
+      _                <- IO.pure(logger.info(s"Retrieved MAML AST for extent ($extent) and cellsize ($cs): ${expr.toString}"))
       paramMap         <- getParams
-      _                <- IO.pure(logger.info(s"Retrieved parameters for extent ($extent) and cellsize ($cs): ${paramMap.asJson.noSpaces}"))
+      _                <- IO.pure(logger.info(s"Retrieved parameters for extent ($extent) and cellsize ($cs): ${paramMap.toString}"))
       vars             <- IO.pure { Vars.varsWithBuffer(expr) }
       params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
                             val thingify = paramMap(varName).extentReification
@@ -50,7 +49,6 @@ object LayerExtent extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)
 
@@ -61,7 +59,6 @@ object LayerExtent extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Map[String, Param], Extent, CellSize) => IO[Interpreted[MultibandTile]] =
     (paramMap: Map[String, Param], extent: Extent, cellsize: CellSize) => {
@@ -75,7 +72,6 @@ object LayerExtent extends LazyLogging {
     param: Param
   )(
     implicit reify: ExtentReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Extent, CellSize) => IO[Interpreted[MultibandTile]] =
     (extent: Extent, cellsize: CellSize) => {

--- a/core/src/main/scala/geotrellis/server/LayerHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/LayerHistogram.scala
@@ -9,7 +9,6 @@ import geotrellis.vector.Extent
 import geotrellis.raster._
 import geotrellis.raster.histogram._
 
-import _root_.io.circe._
 import cats.data.{NonEmptyList => NEL}
 import cats.effect._
 import cats.implicits._
@@ -72,7 +71,6 @@ object LayerHistogram extends LazyLogging {
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): IO[Interpreted[List[Histogram[Double]]]] =
     for {
@@ -105,7 +103,6 @@ object LayerHistogram extends LazyLogging {
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
 
@@ -118,7 +115,6 @@ object LayerHistogram extends LazyLogging {
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Map[String, Param]) => IO[Interpreted[List[Histogram[Double]]]] =
     (paramMap: Map[String, Param]) => {
@@ -133,7 +129,6 @@ object LayerHistogram extends LazyLogging {
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ) = {
     val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT, maxCells)

--- a/core/src/main/scala/geotrellis/server/LayerTms.scala
+++ b/core/src/main/scala/geotrellis/server/LayerTms.scala
@@ -8,8 +8,6 @@ import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
 import com.azavea.maml.eval._
 import com.typesafe.scalalogging.LazyLogging
-import io.circe._
-import io.circe.syntax._
 import cats.effect._
 import cats.implicits._
 import geotrellis.raster._
@@ -35,14 +33,13 @@ object LayerTms extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Int, Int, Int) => IO[Interpreted[MultibandTile]] = (z: Int, x: Int, y: Int) => {
     for {
       expr             <- getExpression
-      _                <- IO.pure(logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.asJson.noSpaces}"))
+      _                <- IO.pure(logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.toString}"))
       paramMap         <- getParams
-      _                <- IO.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.asJson.noSpaces}"))
+      _                <- IO.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.toString}"))
       vars             <- IO.pure { Vars.varsWithBuffer(expr) }
       params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
                             val eval = paramMap(varName).tmsReification(buffer)
@@ -62,7 +59,6 @@ object LayerTms extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)
 
@@ -73,7 +69,6 @@ object LayerTms extends LazyLogging {
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ): (Map[String, Param], Int, Int, Int) => IO[Interpreted[MultibandTile]] =
     (paramMap: Map[String, Param], z: Int, x: Int, y: Int) => {
@@ -87,7 +82,6 @@ object LayerTms extends LazyLogging {
     param: Param
   )(
     implicit reify: TmsReification[Param],
-             enc: Encoder[Param],
              contextShift: ContextShift[IO]
   ) = (z: Int, x: Int, y: Int) => {
     val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT)

--- a/core/src/main/scala/geotrellis/server/vlm/gdal/GDALNode.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/gdal/GDALNode.scala
@@ -40,8 +40,6 @@ object GDALNode extends RasterSourceUtils {
   implicit val gdalNodeRasterExtents: HasRasterExtents[GDALNode] = new HasRasterExtents[GDALNode] {
     def rasterExtents(self: GDALNode)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
       getRasterExtents(self.uri.toString)
-    def crs(self: GDALNode)(implicit contextShift: ContextShift[IO]): IO[CRS] =
-      getCRS(self.uri.toString)
   }
 
   implicit val gdalNodeTmsReification: TmsReification[GDALNode] = new TmsReification[GDALNode] {

--- a/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
@@ -33,8 +33,6 @@ object GeoTiffNode extends RasterSourceUtils {
   implicit val cogNodeRasterExtents: HasRasterExtents[GeoTiffNode] = new HasRasterExtents[GeoTiffNode] {
     def rasterExtents(self: GeoTiffNode)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
       getRasterExtents(self.uri.toString)
-    def crs(self: GeoTiffNode)(implicit contextShift: ContextShift[IO]): IO[CRS] =
-      getCRS(self.uri.toString)
   }
 
   implicit val cogNodeTmsReification: TmsReification[GeoTiffNode] = new TmsReification[GeoTiffNode] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val circeVer         = "0.10.0"
   val gtVer            = "3.0.0-SNAPSHOT"
-  val gtcVer           = "0.4.0"
+  val gtcVer           = "0.5.0"
   val http4sVer        = "0.19.0"
   val scalaVer         = "2.11.12"
   val crossScalaVer    = Seq(scalaVer, "2.12.7")


### PR DESCRIPTION
Some of the restrictions put in place at first no longer make a great deal of sense.|

`CRS` is not strictly necessary for getting histograms (which is the primary use for `HasRasterExtents`). That required method is no longer enforced.

`Encoder`s were useful for proper error reporting, but placed unnecessary burdens upon downstream usage. All `Layer___`s methods have had this requirement lifted