### PR TITLE
Abstract over effect types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,11 +126,11 @@ lazy val core = project
   )
 
 lazy val example = project
+  .settings(moduleName := "geotrellis-server-example")
   .settings(commonSettings)
   .settings(publishSettings)
   .dependsOn(core)
   .settings(
-    moduleName := "geotrellis-server-example",
     assemblyJarName in assembly := "geotrellis-server-example.jar",
     libraryDependencies ++= Seq(
       http4sDsl,

--- a/core/src/main/scala/geotrellis/server/ExtentReification.scala
+++ b/core/src/main/scala/geotrellis/server/ExtentReification.scala
@@ -13,6 +13,6 @@ import java.util.UUID
 
 @typeclass trait ExtentReification[A] {
   @op("kind") def kind(self: A): MamlKind
-  @op("extentReification") def extentReification(self: A)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal]
+  @op("extentReification") def extentReification[F[_]](self: A)(implicit F: ConcurrentEffect[F]): (Extent, CellSize) => F[Literal]
 }
 

--- a/core/src/main/scala/geotrellis/server/HasRasterExtents.scala
+++ b/core/src/main/scala/geotrellis/server/HasRasterExtents.scala
@@ -9,6 +9,6 @@ import cats.effect._
 import simulacrum._
 
 @typeclass trait HasRasterExtents[A] {
-  @op("rasterExtents") def rasterExtents(self: A)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]]
+  @op("rasterExtents") def rasterExtents[F[_]](self: A)(implicit F: ConcurrentEffect[F]): F[NEL[RasterExtent]]
 }
 

--- a/core/src/main/scala/geotrellis/server/LayerExtent.scala
+++ b/core/src/main/scala/geotrellis/server/LayerExtent.scala
@@ -2,6 +2,7 @@ package geotrellis.server
 
 import ExtentReification.ops._
 
+import geotrellis.raster._
 import geotrellis.vector.Extent
 import com.azavea.maml.util.Vars
 import com.azavea.maml.error._
@@ -9,73 +10,74 @@ import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
 import com.azavea.maml.eval._
 import com.typesafe.scalalogging.LazyLogging
-import io.circe._
-import io.circe.syntax._
 import cats._
-import cats.data.{NonEmptyList => NEL}
 import cats.effect._
 import cats.implicits._
-import geotrellis.raster._
+import cats.data.{NonEmptyList => NEL}
 
 
 object LayerExtent extends LazyLogging {
 
   // Provide IOs for both expression and params, get back a tile
-  def apply[Param](
-    getExpression: IO[Expression],
-    getParams: IO[Map[String, Param]],
+  def apply[F[_], Par[_], Param](
+    getExpression: F[Expression],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             contextShift: ContextShift[IO]
-  ): (Extent, CellSize) => IO[Interpreted[MultibandTile]]  = (extent: Extent, cs: CellSize) =>  {
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Extent, CellSize) => F[Interpreted[MultibandTile]]  = (extent: Extent, cs: CellSize) =>  {
     for {
       expr             <- getExpression
-      _                <- IO { logger.trace(s"[LayerExtent] Retrieved MAML AST for extent ($extent) and cellsize ($cs): ${expr.toString}") }
+      _                <- F.delay { logger.trace(s"[LayerExtent] Retrieved MAML AST for extent ($extent) and cellsize ($cs): ${expr.toString}") }
       paramMap         <- getParams
-      _                <- IO { logger.trace(s"[LayerExtent] Retrieved parameters for extent ($extent) and cellsize ($cs): ${paramMap.toString}") }
-      vars             <- IO { Vars.varsWithBuffer(expr) }
+      _                <- F.delay { logger.trace(s"[LayerExtent] Retrieved parameters for extent ($extent) and cellsize ($cs): ${paramMap.toString}") }
+      vars             <- F.delay { Vars.varsWithBuffer(expr) }
       params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
                             val thingify = paramMap(varName).extentReification
                             thingify(extent, cs).map(varName -> _)
                           } map { _.toMap }
-      reified          <- IO { Expression.bindParams(expr, params) }
+      reified          <- F.delay { Expression.bindParams(expr, params) }
     } yield reified.andThen(interpreter(_)).andThen(_.as[MultibandTile])
   }
 
-  def generateExpression[Param](
+  def generateExpression[F[_], Par[_], Param](
     mkExpr: Map[String, Param] => Expression,
-    getParams: IO[Map[String, Param]],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             contextShift: ContextShift[IO]
-  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ) = apply[F, Par, Param](getParams.map(mkExpr(_)), getParams, interpreter)
 
 
   /** Provide an expression and expect arguments to fulfill its needs */
-  def curried[Param](
+  def curried[F[_], Par[_], Param](
     expr: Expression,
     interpreter: BufferingInterpreter
   )(
     implicit reify: ExtentReification[Param],
-             contextShift: ContextShift[IO]
-  ): (Map[String, Param], Extent, CellSize) => IO[Interpreted[MultibandTile]] =
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Map[String, Param], Extent, CellSize) => F[Interpreted[MultibandTile]] =
     (paramMap: Map[String, Param], extent: Extent, cellsize: CellSize) => {
-      val eval = apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter)
+      val eval = apply[F, Par, Param](F.pure(expr), F.pure(paramMap), interpreter)
       eval(extent, cellsize)
     }
 
 
   /** The identity endpoint (for simple display of raster) */
-  def identity[Param](
+  def identity[F[_], Par[_], Param](
     param: Param
   )(
     implicit reify: ExtentReification[Param],
-             contextShift: ContextShift[IO]
-  ): (Extent, CellSize) => IO[Interpreted[MultibandTile]] =
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Extent, CellSize) => F[Interpreted[MultibandTile]] =
     (extent: Extent, cellsize: CellSize) => {
-      val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT)
+      val eval = curried[F, Par, Param](RasterVar("identity"), BufferingInterpreter.DEFAULT)
       eval(Map("identity" -> param), extent, cellsize)
     }
 }

--- a/core/src/main/scala/geotrellis/server/LayerHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/LayerHistogram.scala
@@ -11,10 +11,11 @@ import geotrellis.raster._
 import geotrellis.raster.histogram._
 
 import com.typesafe.scalalogging.LazyLogging
-import cats.data.{NonEmptyList => NEL}
+import cats._
 import cats.effect._
 import cats.implicits._
 import cats.syntax.either._
+import cats.data.{NonEmptyList => NEL}
 
 import scala.collection.mutable
 
@@ -24,74 +25,78 @@ object LayerHistogram extends LazyLogging {
   case class NoSuitableHistogramResolution(cells: Int) extends Throwable
   case class RequireIntersectingSources() extends Throwable
 
-  // Provide IOs for both expression and params, get back a tile
-  def apply[Param](
-    getExpression: IO[Expression],
-    getParams: IO[Map[String, Param]],
+  // Provide effects that return both expression and params, get back a tile
+  def apply[F[_], Par[_], Param](
+    getExpression: F[Expression],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter,
     maxCells: Int
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
-  ): IO[Interpreted[List[Histogram[Double]]]] =
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): F[Interpreted[NEL[Histogram[Double]]]] =
     for {
       params            <- getParams
       rasterExtents     <- NEL.fromListUnsafe(params.values.toList)
                              .map(_.rasterExtents)
                              .parSequence
                              .map(_.flatten)
-      intersection      <- IO { SampleUtils.intersectExtents(rasterExtents.map(_.extent))
+      intersection      <- F.delay { SampleUtils.intersectExtents(rasterExtents.map(_.extent))
                                   .getOrElse(throw new RequireIntersectingSources()) }
-      _                 <- IO { logger.trace(s"[LayerHistogram] Intersection of provided layer extents calculated: $intersection") }
-      cellSize          <- IO { SampleUtils.chooseLargestCellSize(rasterExtents.map(_.cellSize)) }
-      _                 <- IO { logger.trace(s"[LayerHistogram] Largest cell size of provided layers calculated: $cellSize") }
-      mbtileForExtent   <- IO { LayerExtent(getExpression, getParams, interpreter) }
-      _                 <- IO { logger.trace(s"[LayerHistogram] calculating histogram from (approximately) ${intersection.area / (cellSize.width * cellSize.height)} cells") }
+      _                 <- F.delay { logger.trace(s"[LayerHistogram] Intersection of provided layer extents calculated: $intersection") }
+      cellSize          <- F.delay { SampleUtils.chooseLargestCellSize(rasterExtents.map(_.cellSize)) }
+      _                 <- F.delay { logger.trace(s"[LayerHistogram] Largest cell size of provided layers calculated: $cellSize") }
+      mbtileForExtent   <- F.delay { LayerExtent(getExpression, getParams, interpreter) }
+      _                 <- F.delay { logger.trace(s"[LayerHistogram] calculating histogram from (approximately) ${intersection.area / (cellSize.width * cellSize.height)} cells") }
       interpretedTile   <- mbtileForExtent(intersection, cellSize)
     } yield {
       interpretedTile.map { mbtile =>
-        mbtile.bands.map { band  => StreamingHistogram.fromTile(band) }.toList
+        NEL.fromListUnsafe(mbtile.bands.map { band  => StreamingHistogram.fromTile(band) }.toList)
       }
     }
 
-  def generateExpression[Param](
+  def generateExpression[F[_], Par[_], Param](
     mkExpr: Map[String, Param] => Expression,
-    getParams: IO[Map[String, Param]],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter,
     maxCells: Int
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
-  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ) = apply[F, Par, Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
 
 
   /** Provide an expression and expect arguments to fulfill its needs */
-  def curried[Param](
+  def curried[F[_], Par[_], Param](
     expr: Expression,
     interpreter: BufferingInterpreter,
     maxCells: Int
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
-  ): (Map[String, Param]) => IO[Interpreted[List[Histogram[Double]]]] =
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Map[String, Param]) => F[Interpreted[NEL[Histogram[Double]]]] =
     (paramMap: Map[String, Param]) => {
-      apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter, maxCells)
+      apply[F, Par, Param](F.pure(expr), F.pure(paramMap), interpreter, maxCells)
     }
 
 
   /** The identity endpoint (for simple display of raster) */
-  def identity[Param](
+  def identity[F[_], Par[_], Param](
     param: Param,
     maxCells: Int
   )(
     implicit reify: ExtentReification[Param],
              extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
   ) = {
-    val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT, maxCells)
+    val eval = curried[F, Par, Param](RasterVar("identity"), BufferingInterpreter.DEFAULT, maxCells)
     eval(Map("identity" -> param))
   }
 

--- a/core/src/main/scala/geotrellis/server/LayerTms.scala
+++ b/core/src/main/scala/geotrellis/server/LayerTms.scala
@@ -8,6 +8,7 @@ import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
 import com.azavea.maml.eval._
 import com.typesafe.scalalogging.LazyLogging
+import cats._
 import cats.effect._
 import cats.implicits._
 import geotrellis.raster._
@@ -20,71 +21,75 @@ object LayerTms extends LazyLogging {
    *  which takes z, x, and y coordinates and returns the corresponding tile.
    *
    * @tparam Param a type whose instances can refer to layers
-   * @param getExpression an [[IO]] yielding a description of the map algebra
+   * @param getExpression an [[F]] yielding a description of the map algebra
    *                      to be carried out
-   * @param getParams an [[IO]] yielding a map from source node ID to some stand-in
+   * @param getParams an [[F]] yielding a map from source node ID to some stand-in
    *                  for a tile source
    * @param interpreter a MAML-compliant interpreter (with buffering)
    * @return a function from (Int, Int, Int) to a Tile corresponding to the Param provided
    */
-  def apply[Param](
-    getExpression: IO[Expression],
-    getParams: IO[Map[String, Param]],
+  def apply[F[_], Par[_], Param](
+    getExpression: F[Expression],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             contextShift: ContextShift[IO]
-  ): (Int, Int, Int) => IO[Interpreted[MultibandTile]] = (z: Int, x: Int, y: Int) => {
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Int, Int, Int) => F[Interpreted[MultibandTile]] = (z: Int, x: Int, y: Int) => {
     for {
       expr             <- getExpression
-      _                <- IO.pure(logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.toString}"))
+      _                <- F.pure(logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.toString}"))
       paramMap         <- getParams
-      _                <- IO.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.toString}"))
-      vars             <- IO.pure { Vars.varsWithBuffer(expr) }
+      _                <- F.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.toString}"))
+      vars             <- F.delay { Vars.varsWithBuffer(expr) }
       params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
                             val eval = paramMap(varName).tmsReification(buffer)
                             eval(z, x, y).map(varName -> _)
                           } map { _.toMap }
-      reified          <- IO.pure { Expression.bindParams(expr, params) }
+      reified          <- F.pure { Expression.bindParams(expr, params) }
     } yield reified.andThen(interpreter(_)).andThen(_.as[MultibandTile])
   }
 
 
   /** Provide a function to produce an expression given a set of arguments and an
-    *  IO for getting arguments; getting back a tile
+    *  [[F]] for getting arguments; getting back a tile
     */
-  def generateExpression[Param](
+  def generateExpression[F[_], Par[_], Param](
     mkExpr: Map[String, Param] => Expression,
-    getParams: IO[Map[String, Param]],
+    getParams: F[Map[String, Param]],
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             contextShift: ContextShift[IO]
-  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter)
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ) = apply[F, Par, Param](getParams.map(mkExpr(_)), getParams, interpreter)
 
 
   /** Provide an expression and expect arguments to fulfill its needs */
-  def curried[Param](
+  def curried[F[_], Par[_], Param](
     expr: Expression,
     interpreter: BufferingInterpreter
   )(
     implicit reify: TmsReification[Param],
-             contextShift: ContextShift[IO]
-  ): (Map[String, Param], Int, Int, Int) => IO[Interpreted[MultibandTile]] =
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
+  ): (Map[String, Param], Int, Int, Int) => F[Interpreted[MultibandTile]] =
     (paramMap: Map[String, Param], z: Int, x: Int, y: Int) => {
-      val eval = apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter)
+      val eval = apply[F, Par, Param](F.pure(expr), F.pure(paramMap), interpreter)
       eval(z, x, y)
     }
 
 
   /** The identity endpoint (for simple display of raster) */
-  def identity[Param](
+  def identity[F[_], Par[_], Param](
     param: Param
   )(
     implicit reify: TmsReification[Param],
-             contextShift: ContextShift[IO]
+             F: ConcurrentEffect[F],
+             P: Parallel[F, Par]
   ) = (z: Int, x: Int, y: Int) => {
-    val eval = curried(RasterVar("identity"), BufferingInterpreter.DEFAULT)
+    val eval = curried[F, Par, Param](RasterVar("identity"), BufferingInterpreter.DEFAULT)
     eval(Map("identity" -> param), z, x, y)
   }
 

--- a/core/src/main/scala/geotrellis/server/TmsReification.scala
+++ b/core/src/main/scala/geotrellis/server/TmsReification.scala
@@ -7,6 +7,6 @@ import simulacrum._
 
 @typeclass trait TmsReification[A] {
   @op("kind") def kind(self: A): MamlKind
-  @op("tmsReification") def tmsReification(self: A, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal]
+  @op("tmsReification") def tmsReification[F[_]](self: A, buffer: Int)(implicit F: ConcurrentEffect[F]): (Int, Int, Int) => F[Literal]
 }
 

--- a/core/src/main/scala/geotrellis/server/vlm/gdal/GDALNode.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/gdal/GDALNode.scala
@@ -12,6 +12,7 @@ import geotrellis.vector.Extent
 import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
 import _root_.io.circe._
 import _root_.io.circe.generic.semiauto._
+import cats.implicits._
 import cats.effect._
 import cats.data.{NonEmptyList => NEL}
 
@@ -26,33 +27,37 @@ object GDALNode extends RasterSourceUtils {
   implicit val gdalNodeDecoder: Decoder[GDALNode] = deriveDecoder[GDALNode]
 
   implicit val gdalNodeRasterExtents: HasRasterExtents[GDALNode] = new HasRasterExtents[GDALNode] {
-    def rasterExtents(self: GDALNode)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
+    def rasterExtents[F[_]](self: GDALNode)(implicit F: ConcurrentEffect[F]): F[NEL[RasterExtent]] =
       getRasterExtents(self.uri.toString)
   }
 
   implicit val gdalNodeTmsReification: TmsReification[GDALNode] = new TmsReification[GDALNode] {
     def kind(self: GDALNode): MamlKind = MamlKind.Image
-    def tmsReification(self: GDALNode, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
-      def fetch(xCoord: Int, yCoord: Int) =
-        fetchTile(self.uri.toString, z, xCoord, yCoord)
-          .map(_.tile)
-          .map(_.band(self.band))
+    def tmsReification[F[_]](self: GDALNode, buffer: Int)(implicit F: ConcurrentEffect[F]): (Int, Int, Int) => F[Literal] =
+      (z: Int, x: Int, y: Int) => {
+        def fetch(xCoord: Int, yCoord: Int) =
+          fetchTile(self.uri.toString, z, xCoord, yCoord)
+            .map(_.tile)
+            .map(_.band(self.band))
 
-      fetch(x, y).map { tile =>
-        val extent = tmsLevels(z).mapTransform.keyToExtent(x, y)
-        RasterLit(Raster(MultibandTile(tile), extent))
+        fetch(x, y).map { tile =>
+          val extent = tmsLevels(z).mapTransform.keyToExtent(x, y)
+          RasterLit(Raster(MultibandTile(tile), extent))
+        }
       }
-    }
   }
 
   implicit val gdalNodeExtentReification: ExtentReification[GDALNode] = new ExtentReification[GDALNode] {
     def kind(self: GDALNode): MamlKind = MamlKind.Image
-    def extentReification(self: GDALNode)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal] = (extent: Extent, cs: CellSize) => {
-      getRasterSource(self.uri.toString)
-        .resample(TargetRegion(RasterExtent(extent, cs)), NearestNeighbor, AutoHigherResolution)
-        .read(extent, self.band :: Nil)
-        .map { RasterLit(_) }
-        .toIO { new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}") }
-    }
+    def extentReification[F[_]](self: GDALNode)(implicit F: ConcurrentEffect[F]): (Extent, CellSize) => F[Literal] =
+      (extent: Extent, cs: CellSize) => F.delay {
+        getRasterSource(self.uri.toString)
+          .resample(TargetRegion(RasterExtent(extent, cs)), NearestNeighbor, AutoHigherResolution)
+          .read(extent, self.band :: Nil)
+          .map { RasterLit(_) } match {
+            case Some(lit) => lit
+            case None => throw new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}")
+          }
+      }
   }
 }

--- a/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
@@ -13,7 +13,9 @@ import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
 
 import _root_.io.circe._
 import _root_.io.circe.generic.semiauto._
+import cats._
 import cats.effect._
+import cats.implicits._
 import cats.data.{NonEmptyList => NEL}
 
 import java.net.URI
@@ -27,13 +29,13 @@ object GeoTiffNode extends RasterSourceUtils {
   implicit val cogNodeDecoder: Decoder[GeoTiffNode] = deriveDecoder[GeoTiffNode]
 
   implicit val cogNodeRasterExtents: HasRasterExtents[GeoTiffNode] = new HasRasterExtents[GeoTiffNode] {
-    def rasterExtents(self: GeoTiffNode)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] =
+    def rasterExtents[F[_]](self: GeoTiffNode)(implicit F: ConcurrentEffect[F]): F[NEL[RasterExtent]] =
       getRasterExtents(self.uri.toString)
   }
 
   implicit val cogNodeTmsReification: TmsReification[GeoTiffNode] = new TmsReification[GeoTiffNode] {
     def kind(self: GeoTiffNode): MamlKind = MamlKind.Image
-    def tmsReification(self: GeoTiffNode, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
+    def tmsReification[F[_]](self: GeoTiffNode, buffer: Int)(implicit F: ConcurrentEffect[F]): (Int, Int, Int) => F[Literal] = (z: Int, x: Int, y: Int) => {
       def fetch(xCoord: Int, yCoord: Int) =
         fetchTile(self.uri.toString, z, xCoord, yCoord)
           .map(_.tile)
@@ -48,13 +50,18 @@ object GeoTiffNode extends RasterSourceUtils {
 
   implicit val CogNodeExtentReification: ExtentReification[GeoTiffNode] = new ExtentReification[GeoTiffNode] {
     def kind(self: GeoTiffNode): MamlKind = MamlKind.Image
-    def extentReification(self: GeoTiffNode)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[Literal] = (extent: Extent, cs: CellSize) => {
-      getRasterSource(self.uri.toString)
-        .resample(TargetRegion(RasterExtent(extent, cs)), NearestNeighbor, AutoHigherResolution)
-        .read(extent, self.band :: Nil)
-        .map { RasterLit(_) }
-        .toIO { new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}") }
-    }
+    def extentReification[F[_]](
+      self: GeoTiffNode
+    )(implicit F: ConcurrentEffect[F]): (Extent, CellSize) => F[Literal] = (extent: Extent, cs: CellSize) =>
+      F.delay {
+        getRasterSource(self.uri.toString)
+          .resample(TargetRegion(RasterExtent(extent, cs)), NearestNeighbor, AutoHigherResolution)
+          .read(extent, self.band :: Nil)
+          .map { RasterLit(_) } match {
+            case Some(lit) => lit
+            case None => throw new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}")
+          }
+      }
   }
 }
 

--- a/core/src/main/scala/geotrellis/server/vlm/geotiff/util/RangeReaderUtils.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/geotiff/util/RangeReaderUtils.scala
@@ -6,7 +6,8 @@ import geotrellis.spark.io.s3.util.S3RangeReader
 import geotrellis.spark.io.s3.{AmazonS3Client => GTAmazonS3Client}
 import geotrellis.spark.io.http.util.HttpRangeReader
 
-import cats.effect.IO
+import cats.implicits._
+import cats.effect._
 import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3ClientBuilder}
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import org.apache.http.client.utils.URLEncodedUtils
@@ -17,7 +18,7 @@ import java.net.URI
 import java.net.URL
 
 object RangeReaderUtils extends LazyLogging {
-  def fromUri(uri: String): IO[RangeReader] = IO {
+  def fromUri[F[_]](uri: String)(implicit F: ConcurrentEffect[F]): F[RangeReader] = F.delay {
     val javaUri = new URI(uri)
 
     /**

--- a/example/src/main/scala/geotrellis/server/example/ndvi/GDALNdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/GDALNdviServer.scala
@@ -3,6 +3,7 @@ package geotrellis.server.example.ndvi
 import geotrellis.server.example._
 import geotrellis.server.vlm.gdal._
 
+import cats._
 import cats.effect._
 import cats.implicits._
 import fs2._
@@ -33,7 +34,7 @@ object GDALNdviServer extends LazyLogging with IOApp {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO.pure(logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/")))
-      mamlNdviRendering = new NdviService[GDALNode]()
+      mamlNdviRendering = new NdviService[IO, IO.Par, GDALNode]()
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
@@ -33,7 +33,7 @@ object NdviServer extends LazyLogging with IOApp {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO.pure(logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/")))
-      mamlNdviRendering = new NdviService[GeoTiffNode]()
+      mamlNdviRendering = new NdviService[IO, IO.Par, GeoTiffNode]()
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)

--- a/example/src/main/scala/geotrellis/server/example/persistence/GDALPersistenceServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/GDALPersistenceServer.scala
@@ -41,7 +41,7 @@ object GDALPersistenceServer extends LazyLogging with IOApp {
       mamlStore = new ConcurrentLinkedHashMap.Builder[UUID, Expression]()
                     .maximumWeightedCapacity(1000)
                     .build()
-      mamlPersistence = new PersistenceService[HashMapMamlStore, GDALNode](mamlStore)
+      mamlPersistence = new PersistenceService[IO, HashMapMamlStore, GDALNode](mamlStore)
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)

--- a/example/src/main/scala/geotrellis/server/example/persistence/MamlStore.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/MamlStore.scala
@@ -2,16 +2,16 @@ package geotrellis.server.example.persistence
 
 import com.azavea.maml.ast.{Expression, Literal}
 import cats._
-import cats.data.EitherT
-import cats.effect.IO
+import cats.implicits._
+import cats.effect._
 import simulacrum._
 
 import java.util.UUID
 
 
 @typeclass trait MamlStore[A] {
-  @op("getMaml") def getMaml(self: A, key: UUID): IO[Option[Expression]]
-  @op("putMaml") def putMaml(self: A, key: UUID, maml: Expression): IO[Unit]
+  @op("getMaml") def getMaml[F[_]](self: A, key: UUID)(implicit F: ConcurrentEffect[F]): F[Option[Expression]]
+  @op("putMaml") def putMaml[F[_]](self: A, key: UUID, maml: Expression)(implicit F: ConcurrentEffect[F]): F[Unit]
 }
 
 object MamlStore {

--- a/example/src/main/scala/geotrellis/server/example/persistence/PersistenceServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/PersistenceServer.scala
@@ -42,7 +42,7 @@ object PersistenceServer extends LazyLogging with IOApp {
       mamlStore = new ConcurrentLinkedHashMap.Builder[UUID, Expression]()
                     .maximumWeightedCapacity(1000)
                     .build()
-      mamlPersistence = new PersistenceService[HashMapMamlStore, GeoTiffNode](mamlStore)
+      mamlPersistence = new PersistenceService[IO, HashMapMamlStore, GeoTiffNode](mamlStore)
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)

--- a/example/src/main/scala/geotrellis/server/example/persistence/package.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/package.scala
@@ -2,8 +2,9 @@ package geotrellis.server.example
 
 import com.azavea.maml.ast.Expression
 
-import cats.effect.IO
 import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap
+import cats.effect._
+import cats.implicits._
 
 import java.util.UUID
 
@@ -11,11 +12,13 @@ package object persistence {
   type HashMapMamlStore = ConcurrentLinkedHashMap[UUID, Expression]
   implicit val inMemMamlStore: MamlStore[ConcurrentLinkedHashMap[UUID, Expression]] =
     new MamlStore[ConcurrentLinkedHashMap[UUID, Expression]] {
-      def getMaml(self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID): IO[Option[Expression]] =
-        IO.pure { Option(self.get(key)) }
+      def getMaml[F[_]](self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID)(implicit F: ConcurrentEffect[F]): F[Option[Expression]] =
+        F.pure { Option(self.get(key)) }
 
-      def putMaml(self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID, maml: Expression): IO[Unit] =
-        IO.pure { self.put(key, maml) }
+      def putMaml[F[_]](
+        self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID, maml: Expression
+      )(implicit F: ConcurrentEffect[F]): F[Unit] =
+        F.pure { self.put(key, maml) }
     }
 
 }


### PR DESCRIPTION
Instead of using `IO`, we can use an `F` that satisfies the appropriate type classes.