### PR TITLE
Ensure proper io.pure use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.8 --install --fuzzy
+  - rvm use 2.3.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/core/src/main/scala/geotrellis/server/LayerTms.scala
+++ b/core/src/main/scala/geotrellis/server/LayerTms.scala
@@ -37,15 +37,15 @@ object LayerTms extends LazyLogging {
   ): (Int, Int, Int) => IO[Interpreted[MultibandTile]] = (z: Int, x: Int, y: Int) => {
     for {
       expr             <- getExpression
-      _                <- IO.pure(logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.toString}"))
+      _                <- IO { logger.info(s"Retrieved MAML AST at TMS ($z, $x, $y): ${expr.toString}") }
       paramMap         <- getParams
-      _                <- IO.pure(logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.toString}"))
-      vars             <- IO.pure { Vars.varsWithBuffer(expr) }
+      _                <- IO { logger.info(s"Retrieved parameters for TMS ($z, $x, $y): ${paramMap.toString}") }
+      vars             <- IO { Vars.varsWithBuffer(expr) }
       params           <- vars.toList.parTraverse { case (varName, (_, buffer)) =>
                             val eval = paramMap(varName).tmsReification(buffer)
                             eval(z, x, y).map(varName -> _)
                           } map { _.toMap }
-      reified          <- IO.pure { Expression.bindParams(expr, params) }
+      reified          <- IO { Expression.bindParams(expr, params) }
     } yield reified.andThen(interpreter(_)).andThen(_.as[MultibandTile])
   }
 

--- a/example/src/main/scala/geotrellis/server/example/LoadConf.scala
+++ b/example/src/main/scala/geotrellis/server/example/LoadConf.scala
@@ -15,8 +15,8 @@ object LoadConf {
       IO {
         loadConfig[Conf](ConfigFactory.load(configFile))
       }.flatMap {
-        case Left(e) => IO.raiseError[Conf](new ConfigReaderException[Conf](e))
         case Right(config) => IO.pure(config)
+        case Left(e) => IO.raiseError[Conf](new ConfigReaderException[Conf](e))
       }
   }
 }

--- a/example/src/main/scala/geotrellis/server/example/ndvi/GDALNdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/GDALNdviServer.scala
@@ -32,7 +32,7 @@ object GDALNdviServer extends LazyLogging with IOApp {
   val stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/")))
+      _          <- Stream.eval(IO { logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/") })
       mamlNdviRendering = new NdviService[GDALNode]()
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
@@ -32,7 +32,7 @@ object NdviServer extends LazyLogging with IOApp {
   val stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/")))
+      _          <- Stream.eval(IO { logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/") } )
       mamlNdviRendering = new NdviService[GeoTiffNode]()
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)

--- a/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
@@ -36,7 +36,7 @@ object WeightedOverlayServer extends LazyLogging with IOApp {
   def stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/")))
+      _          <- Stream.eval(IO { logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/") })
       overlayService = new WeightedOverlayService()
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)

--- a/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayService.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayService.scala
@@ -104,10 +104,10 @@ class WeightedOverlayService(
     case req @ POST -> Root / IdVar(key) =>
       (for {
          args <- req.as[Map[String, WeightedOverlayDefinition]]
-         _    <- req.bodyAsText.compile.toList flatMap { reqBody =>
-                   IO.pure(logger.info(s"Attempting to store expression (${reqBody.mkString("")}) at key ($key)"))
+         _    <- req.bodyAsText.compile.toList map { reqBody =>
+                   logger.info(s"Attempting to store expression (${reqBody.mkString("")}) at key ($key)")
                  }
-         _    <- IO.pure { demoStore.put(key, args.asJson) }
+         _    <- IO { demoStore.put(key, args.asJson) }
       } yield ()).attempt flatMap {
         case Right(_) =>
           // In parallel, store histogram

--- a/example/src/main/scala/geotrellis/server/example/persistence/GDALPersistenceServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/GDALPersistenceServer.scala
@@ -36,7 +36,7 @@ object GDALPersistenceServer extends LazyLogging with IOApp {
   val stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing persistence demo at ${conf.http.interface}:${conf.http.port}/")))
+      _          <- Stream.eval(IO { logger.info(s"Initializing persistence demo at ${conf.http.interface}:${conf.http.port}/") })
       // This hashmap has a [MamlStore] implementation
       mamlStore = new ConcurrentLinkedHashMap.Builder[UUID, Expression]()
                     .maximumWeightedCapacity(1000)

--- a/example/src/main/scala/geotrellis/server/example/persistence/PersistenceServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/PersistenceServer.scala
@@ -37,7 +37,7 @@ object PersistenceServer extends LazyLogging with IOApp {
   val stream: Stream[IO, ExitCode] = {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
-      _          <- Stream.eval(IO.pure(logger.info(s"Initializing persistence demo at ${conf.http.interface}:${conf.http.port}/")))
+      _          <- Stream.eval(IO { logger.info(s"Initializing persistence demo at ${conf.http.interface}:${conf.http.port}/") })
       // This hashmap has a [MamlStore] implementation
       mamlStore = new ConcurrentLinkedHashMap.Builder[UUID, Expression]()
                     .maximumWeightedCapacity(1000)

--- a/example/src/main/scala/geotrellis/server/example/persistence/PersistenceService.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/PersistenceService.scala
@@ -50,7 +50,7 @@ class PersistenceService[Store, Param](
     case req @ POST -> Root / IdVar(key) =>
       (for {
          expr <- req.as[Expression]
-         _    <- IO.pure(logger.info(s"Attempting to store expression (${req.bodyAsText}) at key ($key)"))
+         _    <- IO { logger.info(s"Attempting to store expression (${req.bodyAsText}) at key ($key)") }
          res  <- store.putMaml(key, expr)
        } yield res).attempt flatMap {
         case Right(created) =>

--- a/example/src/main/scala/geotrellis/server/example/persistence/package.scala
+++ b/example/src/main/scala/geotrellis/server/example/persistence/package.scala
@@ -12,10 +12,10 @@ package object persistence {
   implicit val inMemMamlStore: MamlStore[ConcurrentLinkedHashMap[UUID, Expression]] =
     new MamlStore[ConcurrentLinkedHashMap[UUID, Expression]] {
       def getMaml(self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID): IO[Option[Expression]] =
-        IO.pure { Option(self.get(key)) }
+        IO { Option(self.get(key)) }
 
       def putMaml(self: ConcurrentLinkedHashMap[UUID, Expression], key: UUID, maml: Expression): IO[Unit] =
-        IO.pure { self.put(key, maml) }
+        IO { self.put(key, maml) }
     }
 
 }


### PR DESCRIPTION
`IO.pure` does *not* defer computation and should be used with care only when no/trivial work is being done. This PR fixes our uses and addresses some awkward `IO` uses