### PR TITLE
Serve tiles as JPEGs or PNGs based on request format

### DIFF
--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/Constants.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/Constants.scala
@@ -1,14 +1,17 @@
 package geotrellis.server.ogc.wms
 
+object Formats extends Enumeration {
+  val GeoTiff, Png, Jpg = Value
+}
 
 object Constants {
   // Map of incoming format string to normalized format string for supported formats.
   val SUPPORTED_FORMATS =
     Map(
-      "geotiff" -> "geotiff",
-      "geotif" -> "geotiff",
-      "image/png" -> "png",
-      "image/geotiff" -> "geotiff",
-      "image/jpeg" -> "jpeg"
+      "geotiff" -> Formats.GeoTiff,
+      "geotif" -> Formats.GeoTiff,
+      "image/png" -> Formats.Png,
+      "image/geotiff" -> Formats.GeoTiff,
+      "image/jpeg" -> Formats.Jpg
     )
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/RasterSourcesModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/RasterSourcesModel.scala
@@ -68,13 +68,13 @@ case class RasterSourcesModel(
       getLayerColorMap(layerModel, wmsReq.styles.headOption) match {
         case Some(colorMap) =>
           wmsReq.format match {
-            case "png" => raster.tile.band(bandIndex = 0).renderPng(colorMap).bytes
-            case "jpeg" => raster.tile.band(bandIndex = 0).renderJpg(colorMap).bytes
+            case Formats.Png => raster.tile.band(bandIndex = 0).renderPng(colorMap).bytes
+            case Formats.Jpg => raster.tile.band(bandIndex = 0).renderJpg(colorMap).bytes
           }
         case None =>
           wmsReq.format match {
-            case "png" => raster.tile.band(bandIndex = 0).renderPng.bytes
-            case "jpeg" => raster.tile.band(bandIndex = 0).renderJpg.bytes
+            case Formats.Png => raster.tile.band(bandIndex = 0).renderPng.bytes
+            case Formats.Jpg => raster.tile.band(bandIndex = 0).renderJpg.bytes
           }
       }
     }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/RasterSourcesModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/RasterSourcesModel.scala
@@ -67,9 +67,15 @@ case class RasterSourcesModel(
     } yield {
       getLayerColorMap(layerModel, wmsReq.styles.headOption) match {
         case Some(colorMap) =>
-          raster.tile.band(bandIndex = 0).renderPng(colorMap).bytes
+          wmsReq.format match {
+            case "png" => raster.tile.band(bandIndex = 0).renderPng(colorMap).bytes
+            case "jpeg" => raster.tile.band(bandIndex = 0).renderJpg(colorMap).bytes
+          }
         case None =>
-          raster.tile.band(bandIndex = 0).renderPng.bytes
+          wmsReq.format match {
+            case "png" => raster.tile.band(bandIndex = 0).renderPng.bytes
+            case "jpeg" => raster.tile.band(bandIndex = 0).renderJpg.bytes
+          }
       }
     }
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
@@ -38,7 +38,7 @@ object WmsParams {
     layers: List[String],
     styles: List[String],
     boundingBox: Extent,
-    format: String,
+    format: Formats.Value,
     width: Int,
     height: Int,
     crs: CRS


### PR DESCRIPTION
# Overview

Serve tiles as JPEGs or PNGs based on request format.

# Screenshot

JPEG tiles in QGIS:

![qgis_gt_server_jpeg](https://user-images.githubusercontent.com/2926237/52437235-69f3b480-2ae4-11e9-8662-121cdfbf9a45.png)
