### PR TITLE
Add WMS Service Metadata Configuration

### DIFF
--- a/ogc/src/main/resources/application.conf
+++ b/ogc/src/main/resources/application.conf
@@ -1,3 +1,29 @@
+wms {
+    service-metadata {
+        name = "WMS"
+        title = "GeoTrellis Service"
+        online-resource {}
+        keyword-list = {
+            keyword = ["geotrellis", "catalog"]
+        }
+        contact-information {
+            contact-person-primary {
+                contact-person = "Eugene Cheipesh"
+                contact-organization = "Azavea"
+            }
+            contact-position = "Developer"
+            contact-address = {
+                address-type = "Office"
+                address = "990 Spring Garden St."
+                city = "Philadelphia"
+                state-or-province = "PA",
+                post-code = "19087",
+                country = "USA")
+            }
+        }
+    }
+}
+
 color-ramps = {
     "red-to-blue": [
         0x2A2E7FFF, 0x3D5AA9FF, 0x4698D3FF, 0x39C6F0FF,

--- a/ogc/src/main/scala/geotrellis/server/ogc/Server.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/Server.scala
@@ -36,7 +36,7 @@ object Server extends LazyLogging with IOApp {
       _          <- Stream.eval(IO.pure(logger.info(s"Advertising service URL at ${conf.serviceUrl}")))
       simpleLayers = conf.layers.collect { case ssc@SimpleSourceConf(_, _, _, _) => ssc.model }
       mapAlgebraLayers = conf.layers.collect { case mal@MapAlgebraSourceConf(_, _, _, _) => mal.model(simpleLayers) }
-      wcsService = new WmsService(RasterSourcesModel(simpleLayers ++ mapAlgebraLayers), conf.serviceUrl)
+      wcsService = new WmsService(RasterSourcesModel(simpleLayers ++ mapAlgebraLayers), conf.serviceUrl, conf.wms.serviceMetadata)
       exitCode   <- BlazeServerBuilder[IO]
         .withIdleTimeout(Duration.Inf) // for test purposes only
         .enableHttp2(true)

--- a/ogc/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
@@ -2,9 +2,16 @@ package geotrellis.server.ogc.conf
 
 import java.net.{InetAddress, URL}
 
+import geotrellis.server.ogc.wms.wmsScope
+import pureconfig.ConfigReader
+import scalaxb.DataRecord
+
+case class WMS(serviceMetadata: opengis.wms.Service)
+
 case class Conf(
   http: Conf.Http,
   service: Conf.Service,
+  wms: WMS,
   layers: List[OgcSourceConf]
 ) {
     def serviceUrl: URL = {
@@ -30,4 +37,27 @@ object Conf {
 
   lazy val conf: Conf = pureconfig.loadConfigOrThrow[Conf]
   implicit def ConfObjectToClass(obj: Conf.type): Conf = conf
+
+  implicit def nameConfigReader: ConfigReader[opengis.wms.Name] =
+    ConfigReader.fromCursor[opengis.wms.Name] { cur =>
+    for {
+      str <- cur.asString.right
+    } yield {
+      opengis.wms.Name.fromString(str, wmsScope)
+    }
+  }
+
+  implicit def keywordConfigReader: ConfigReader[opengis.wms.Keyword] =
+    ConfigReader.fromCursor[opengis.wms.Keyword] { cur =>
+      for {
+        str <- cur.asString.right
+      } yield {
+        opengis.wms.Keyword(str)
+      }
+    }
+
+  // This is a work-around to use pureconfig to read scalaxb generated case classes
+  // DataRecord should never be specified from configuration, this satisfied the resolution
+  // ConfigReader should be the containing class if DataRecord values need to be set
+  implicit def dataRecordReader: ConfigReader[DataRecord[Any]] = null
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
@@ -39,13 +39,9 @@ object Conf {
   implicit def ConfObjectToClass(obj: Conf.type): Conf = conf
 
   implicit def nameConfigReader: ConfigReader[opengis.wms.Name] =
-    ConfigReader.fromCursor[opengis.wms.Name] { cur =>
-    for {
-      str <- cur.asString.right
-    } yield {
+    ConfigReader[String].map { str =>
       opengis.wms.Name.fromString(str, wmsScope)
     }
-  }
 
   implicit def keywordConfigReader: ConfigReader[opengis.wms.Keyword] =
     ConfigReader.fromCursor[opengis.wms.Keyword] { cur =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -20,17 +20,15 @@ import scala.xml.{Elem, NodeSeq}
   * @param serviceUrl URL where this service can be reached with addition of `?request=` query parameter
   * @param defaultCrs Common CRS, all layers must be available in at least this CRS
   */
-class CapabilitiesView(model: RasterSourcesModel, serviceUrl: URL, defaultCrs: CRS = LatLng) {
+class CapabilitiesView(
+  model: RasterSourcesModel,
+  serviceUrl: URL,
+  serviceMetadata: Service,
+  defaultCrs: CRS = LatLng
+) {
 
   def toXML: Elem = {
     import CapabilitiesView._
-
-    val service = Service(
-      Name = Name.fromString("WMS", wmsScope),
-      Title = "GeoTrellis WMS",
-      OnlineResource = OnlineResource(),
-      KeywordList = Some(KeywordList(Keyword("WMS") :: Keyword("GeoTrellis") :: Nil))
-    )
 
     val capability = {
       val getCapabilities = OperationType(
@@ -57,7 +55,7 @@ class CapabilitiesView(model: RasterSourcesModel, serviceUrl: URL, defaultCrs: C
     }
 
     val ret: NodeSeq = scalaxb.toXML[opengis.wms.WMS_Capabilities](
-      obj = WMS_Capabilities(service, capability, Map("@version" -> scalaxb.DataRecord("1.3.0"))),
+      obj = WMS_Capabilities(serviceMetadata, capability, Map("@version" -> scalaxb.DataRecord("1.3.0"))),
       namespace = None,
       elementLabel = Some("WMS_Capabilities"),
       scope = constrainedWMSScope,

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsService.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsService.scala
@@ -26,7 +26,11 @@ import com.typesafe.scalalogging.LazyLogging
 
 import java.net.{URI, URL}
 
-class WmsService(model: RasterSourcesModel, serviceUrl: URL)(implicit contextShift: ContextShift[IO])
+class WmsService(
+  model: RasterSourcesModel,
+  serviceUrl: URL,
+  serviceMetadata: opengis.wms.Service
+)(implicit contextShift: ContextShift[IO])
   extends Http4sDsl[IO]
      with LazyLogging {
 
@@ -51,7 +55,7 @@ class WmsService(model: RasterSourcesModel, serviceUrl: URL)(implicit contextShi
           BadRequest(msg)
 
         case Valid(wmsReq: GetCapabilities) =>
-          Ok.apply(new CapabilitiesView(model, serviceUrl, defaultCrs = LatLng).toXML)
+          Ok.apply(new CapabilitiesView(model, serviceUrl, serviceMetadata, defaultCrs = LatLng).toXML)
 
         case Valid(wmsReq: GetMap) =>
           val re = RasterExtent(wmsReq.boundingBox, wmsReq.width, wmsReq.height)


### PR DESCRIPTION
This approach uses ScalaXB generated case classes to parse them using pureconfig.
While it may lead to some oddities, like requiring inclusion of `online-resource {}` property (which has default constructor) it maxims the configuration and reduces duplication.

The configuration object is threaded to the service to be returned on requests.


Sample configuration:

```
wms {
    service-metadata {
        name = "WMS"
        title = "GeoTrellis Service"
        online-resource {}
        keyword-list = {
            keyword = ["geotrellis", "catalog"]
        }
        contact-information {
            contact-person-primary {
                contact-person = "Eugene Cheipesh"
                contact-organization = "Azavea"
            }
            contact-position = "Developer"
            contact-address = {
                address-type = "Office"
                address = "990 Spring Garden St."
                city = "Philadelphia"
                state-or-province = "PA",
                post-code = "19087",
                country = "USA")
            }
        }
    }
}
```