### PR TITLE
Bump GT contrib version to support MosaicRasterSource

### DIFF
--- a/core/version.sbt
+++ b/core/version.sbt
@@ -1,3 +1,3 @@
 // This version is ignored by sbt-release
 // Make changes here when you'd like to publish a snapshot version only
-version in ThisBuild := "0.16.0-SNAPSHOT"
+version in ThisBuild := "0.1.14"

--- a/ogc/version.sbt
+++ b/ogc/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1.14"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val circeVer         = "0.11.1"
   val gtVer            = "2.2.0"
-  val gtcVer           = "0.9.1"
+  val gtcVer           = "0.10.0"
   val http4sVer        = "0.20.0-M6"
   val scalaVer         = "2.11.12"
   val crossScalaVer    = Seq(scalaVer, "2.12.7")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.1.14-SNAPSHOT"


### PR DESCRIPTION
The prior release (0.1.13) didn't include the appropriate version of geotrellis-contrib. This amends that and (manually) updates the version files which seem not to have been updated via `sbt release` so that we can have a tag matching the release