### PR TITLE
Use gt-contrib sparse stitch

### DIFF
--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
@@ -7,6 +7,7 @@ import geotrellis.raster.resample._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.reproject.ReprojectRasterExtent
 import geotrellis.vector.Extent
+import geotrellis.vector.io._
 import geotrellis.proj4.CRS
 import com.azavea.maml.ast._
 
@@ -50,6 +51,7 @@ object SimpleOgcLayer extends LazyLogging {
       (extent: Extent, cs: CellSize) =>  IO {
         val targetGrid = new GridExtent[Long](extent, cs)
         logger.debug(s"attempting to retrieve layer $self at extent $extent with $cs ${targetGrid.cols}x${targetGrid.rows}")
+        logger.trace(s"Requested extent geojson: ${extent.toPolygon.toGeoJson}")
         val raster: Raster[MultibandTile] = self.source
           .reprojectToRegion(self.crs, targetGrid.toRasterExtent, NearestNeighbor, AutoHigherResolution)
           .read(extent)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val circeVer         = "0.11.1"
   val gtVer            = "3.0.0-M3-SNAPSHOT"
-  val gtcVer           = "3.11.0"
+  val gtcVer           = "3.12.0"
   val http4sVer        = "0.20.0-M6"
   val scalaVer         = "2.11.12"
   val crossScalaVer    = Seq(scalaVer, "2.12.7")
@@ -38,7 +38,7 @@ object Dependencies {
   val kamonPrometheus   = "io.kamon"                      %% "kamon-prometheus"     % "1.0.0"
   val kamonSysMetrics   = "io.kamon"                      %% "kamon-system-metrics" % "1.0.0"
   val kindProjector     = "org.spire-math"                %% "kind-projector"       % "0.9.4"
-  val mamlJvm           = "com.azavea"                    %% "maml-jvm"             % "0.3.0"
+  val mamlJvm           = "com.azavea"                    %% "maml-jvm"             % "0.3.2"
 
   // Note: pureconfig is not yet stable, version 0.10.0 is not binary copatible with 0.9.2 which is used by GT
   val pureConfig        = "com.github.pureconfig"         %% "pureconfig"           % "0.9.2"


### PR DESCRIPTION
Prior to this PR, sparse ingests (a lack of tiles where there is no data as opposed to an empty tile) would cause a few bizarre issues:
1. Imagery was warped under certain circumstances
2. WCS requests commonly failed in QGIS due to 500s
3. Certain WMS GetMap requests would cause 500s

Upon investigation it became clear that the stitching logic from GT core assumed a dense ingest (as that's generally how layers exist and tests baked the assumption in). Sparse stitching logic has been added in `geotrellis-contrib` which, as a result, requires a bump here.