### PR TITLE
Add llextents per WMS layer; properly escape JSON strings

### DIFF
--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -256,7 +256,19 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "addition-house-income"
         title = "test addition"
-        algebra = "{\"args\":[{\"name\":\"us-census-median-household-income\",\"symbol\":\"rasterV\"},{\"name\":\"us-census-median-household-income\",\"symbol\":\"rasterV\"}],\"symbol\":\"+\"}"
+        algebra = {
+          "args" : [
+            {
+              "name" : "us-census-median-household-income",
+              "symbol" : "rasterV"
+            },
+            {
+              "name" : "us-census-median-household-income",
+              "symbol" : "rasterV"
+            }
+          ],
+          "symbol" : "+"
+        }
         styles = [
             {
                 type = "colorrampconf"
@@ -271,7 +283,15 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "us-ned-slope"
         title = "ned slope"
-        algebra = {\"args\":[{\"name\":\"us-ned\",\"symbol\":\"rasterV\"}],\"symbol\":\"fslope\"}
+        algebra = {
+          "args" : [
+            {
+              "name" : "us-ned",
+              "symbol" : "rasterV"
+            }
+          ],
+          "symbol" : "fslope"
+        }
         styles = [
             {
                 type = "colorrampconf"

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -51,7 +51,7 @@ wcs = {
             description = "Geotrellis WCS Service"
             keywords = []
             profile = ["http://azavea.com/wcs-profile"]
-            fees = []
+            fees = ""
             access-constraints = []
         }
         provider = {
@@ -73,7 +73,7 @@ wmts = {
             description = "Geotrellis WMTS Service"
             keywords = []
             profile = ["http://azavea.com/wmts-profile"]
-            fees = []
+            fees = ""
             access-constraints = []
         }
         provider = {
@@ -256,19 +256,7 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "addition-house-income"
         title = "test addition"
-        algebra = {
-          "args" : [
-            {
-              "name" : "us-census-median-household-income",
-              "symbol" : "rasterV"
-            },
-            {
-              "name" : "us-census-median-household-income",
-              "symbol" : "rasterV"
-            }
-          ],
-          "symbol" : "+"
-        }
+        algebra = "{\"args\":[{\"name\":\"us-census-median-household-income\",\"symbol\":\"rasterV\"},{\"name\":\"us-census-median-household-income\",\"symbol\":\"rasterV\"}],\"symbol\":\"+\"}"
         styles = [
             {
                 type = "colorrampconf"

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -271,15 +271,7 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "us-ned-slope"
         title = "ned slope"
-        algebra = {
-          "args" : [
-            {
-              "name" : "us-ned",
-              "symbol" : "rasterV"
-            }
-          ],
-          "symbol" : "fslope"
-        }
+        algebra = {\"args\":[{\"name\":\"us-ned\",\"symbol\":\"rasterV\"}],\"symbol\":\"fslope\"}
         styles = [
             {
                 type = "colorrampconf"

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -112,10 +112,10 @@ object CapabilitiesView {
             .map { code => s"EPSG:$code" }
             .getOrElse(throw new java.lang.Exception(s"Unable to construct EPSG code from $crs"))
         },
-        // TODO: global Extent for the CRS
-        // EX_GeographicBoundingBox =   Some(self.extent.reproject(self.crs, LatLng)).map { case Extent(xmin, ymin, xmax, ymax) =>
-        //  opengis.wms.EX_GeographicBoundingBox(xmin, xmax, ymin, ymax)
-        // },
+        EX_GeographicBoundingBox = {
+          val llExtent = source.extentIn(LatLng)
+          Some(EX_GeographicBoundingBox(llExtent.xmin, llExtent.xmax, llExtent.ymin, llExtent.ymax))
+        },
         BoundingBox = Nil,
         Dimension = Nil,
         Attribution = None,


### PR DESCRIPTION
This PR adds lat/lng extents on each WMS layer and escapes JSON strings in the example configuration (correcting an oversight from bumping to `PureConfig` 0.10.2)