### PR TITLE
Upgrade MAML version

### DIFF
--- a/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
@@ -1,9 +1,14 @@
 package geotrellis.server
 
 import geotrellis.server.extent.SampleUtils
+import geotrellis.server.TestImplicits._
 
 import geotrellis.raster._
 import geotrellis.vector._
+import com.azavea.maml.error._
+import cats._
+import cats.effect._
+import cats.data.{NonEmptyList => NEL}
 import cats.implicits._
 
 import org.scalatest._
@@ -14,7 +19,7 @@ import scala.concurrent.ExecutionContext
 
 class LayerExtentTest extends FunSuite with Matchers {
   implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
-
+  
   test("ability to read a selected extent") {
     val rt = ResourceTile("8x8.tif")
     val eval = LayerExtent.identity(rt)

--- a/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
@@ -2,9 +2,14 @@ package geotrellis.server
 
 import geotrellis.server.extent.SampleUtils
 
+import geotrellis.server.TestImplicits._
 import geotrellis.raster._
 import geotrellis.vector._
+import com.azavea.maml.error._
+import cats._
 import cats.implicits._
+import cats.effect._
+import cats.data.{NonEmptyList => NEL}
 
 import org.scalatest._
 

--- a/core/src/test/scala/geotrellis/server/NoDataHandlingTest.scala
+++ b/core/src/test/scala/geotrellis/server/NoDataHandlingTest.scala
@@ -1,6 +1,8 @@
 package geotrellis.server
 
 import geotrellis.server.vlm._
+import geotrellis.server.TestImplicits._
+
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.AutoHigherResolution
 import geotrellis.proj4._
@@ -12,6 +14,8 @@ import geotrellis.vector.Extent
 import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
 import com.azavea.maml.eval._
+import com.azavea.maml.error._
+import cats._
 import cats.effect._
 import cats.data.{NonEmptyList => NEL}
 import org.scalatest._
@@ -23,7 +27,7 @@ class NoDataHandlingTest extends FunSuite with Matchers with TileAsSourceImplici
   implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
 
   val expr = Addition(List(RasterVar("t1"), RasterVar("t2")))
-  val eval = LayerTms.curried(expr, BufferingInterpreter.DEFAULT)
+  val eval = LayerTms.curried(expr, ConcurrentInterpreter.DEFAULT)
 
   test("NODATA should be respected - user-defined, integer-based source celltype") {
     val t1 = IntUserDefinedNoDataArrayTile((1 to 100).toArray, 10, 10, IntUserDefinedNoDataCellType(1))

--- a/core/src/test/scala/geotrellis/server/package.scala
+++ b/core/src/test/scala/geotrellis/server/package.scala
@@ -1,0 +1,20 @@
+package geotrellis.server
+
+import com.azavea.maml.error._
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.data.{NonEmptyList => NEL}
+
+object TestImplicits {
+  implicit def applicativeErrorIO(implicit applicativeIO: Applicative[IO]): ApplicativeError[IO, NEL[MamlError]] =
+    new ApplicativeError[IO, NEL[MamlError]] {
+      def raiseError[A](e: NEL[MamlError]): IO[A] = IO { throw new Exception(e.map(_.repr).reduce) }
+
+      def handleErrorWith[A](fa: IO[A])(f: NEL[MamlError] => IO[A]): IO[A] = fa
+
+      def pure[A](x: A): IO[A] = applicativeIO.pure(x)
+
+      def ap[A, B](ff:IO[A => B])(fa: IO[A]): IO[B] = applicativeIO.ap(ff)(fa)
+    }
+}

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviServer.scala
@@ -13,6 +13,7 @@ import org.http4s.server.middleware.{CORS, CORSConfig}
 import org.http4s.syntax.kleisli._
 import pureconfig.generic.auto._
 import com.typesafe.scalalogging.LazyLogging
+import com.azavea.maml.eval._
 
 import scala.concurrent.duration._
 
@@ -34,7 +35,7 @@ object NdviServer extends LazyLogging with IOApp {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO { logger.info(s"Initializing NDVI service at ${conf.http.interface}:${conf.http.port}/") } )
-      mamlNdviRendering = new NdviService[GeoTiffNode]()
+      mamlNdviRendering = new NdviService[GeoTiffNode](ConcurrentInterpreter.DEFAULT)
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)
@@ -47,4 +48,3 @@ object NdviServer extends LazyLogging with IOApp {
   override def run(args: List[String]): IO[ExitCode] =
     stream.compile.drain.as(ExitCode.Success)
 }
-

--- a/example/src/main/scala/geotrellis/server/example/ndvi/NdviService.scala
+++ b/example/src/main/scala/geotrellis/server/example/ndvi/NdviService.scala
@@ -6,6 +6,7 @@ import geotrellis.raster.render._
 import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
 import com.azavea.maml.eval._
+import com.azavea.maml.error._
 
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
@@ -15,13 +16,15 @@ import _root_.io.circe.parser._
 import _root_.io.circe.syntax._
 import cats.data._
 import Validated._
+import cats._
+import cats.data.{NonEmptyList => NEL}
 import cats.effect._
 import com.typesafe.scalalogging.LazyLogging
 
 import java.net.URLDecoder
 
 class NdviService[Param](
-  interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
+  interpreter: Interpreter[IO]
 )(implicit contextShift: ContextShift[IO],
            enc: Encoder[Param],
            dec: Decoder[Param],
@@ -53,6 +56,7 @@ class NdviService[Param](
       ))
     )
 
+  implicit val applicativeErrorIO: ApplicativeError[IO, NEL[MamlError]] = ???
   final val eval = LayerTms.curried(ndvi, interpreter)
 
   // http://0.0.0.0:9000/{z}/{x}/{y}.png
@@ -74,4 +78,3 @@ class NdviService[Param](
       }
   }
 }
-

--- a/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
+++ b/example/src/main/scala/geotrellis/server/example/overlay/WeightedOverlayServer.scala
@@ -14,6 +14,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.{CORS, CORSConfig}
 import org.http4s.syntax.kleisli._
 import pureconfig.generic.auto._
+import com.azavea.maml.eval._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -38,7 +39,7 @@ object WeightedOverlayServer extends LazyLogging with IOApp {
     for {
       conf       <- Stream.eval(LoadConf().as[ExampleConf])
       _          <- Stream.eval(IO { logger.info(s"Initializing Weighted Overlay at ${conf.http.interface}:${conf.http.port}/") })
-      overlayService = new WeightedOverlayService()
+      overlayService = new WeightedOverlayService(ConcurrentInterpreter.DEFAULT)
       exitCode   <- BlazeServerBuilder[IO]
         .enableHttp2(true)
         .bindHttp(conf.http.port, conf.http.interface)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   val kamonPrometheus     = "io.kamon"                      %% "kamon-prometheus"     % "1.0.0"
   val kamonSysMetrics     = "io.kamon"                      %% "kamon-system-metrics" % "1.0.0"
   val kindProjector       = "org.spire-math"                %% "kind-projector"       % "0.9.4"
-  val mamlJvm             = "com.azavea"                    %% "maml-jvm"             % "0.3.2"
+  val mamlJvm             = "com.azavea.geotrellis"          % "maml-jvm_2.11"        % "0.4.0"
 
   val pureConfig        = "com.github.pureconfig"         %% "pureconfig"           % "0.10.2"
   val scaffeine         = "com.github.blemale"            %% "scaffeine"            % "2.6.0"


### PR DESCRIPTION
This PR upgrades the MAML version to `0.4.0` and fixes some compilation errors as a result of upgrading. 

`ogc/compile`, `core/compile`, and `example/compile` should succeed with no errors.

Closes https://github.com/azavea/raster-foundry-platform/issues/727