### PR TITLE
Provide ansi dep for 2.11 and 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import Dependencies._
 import microsites._
 
+
 addCommandAlias("bintrayPublish", ";publish;bintrayRelease")
 
 scalaVersion := scalaVer
@@ -246,13 +247,18 @@ lazy val ogcExample = (project in file("ogc-example"))
       pureConfig,
       scaffeine,
       scalatest,
-      decline,
-      ansiColors
+      decline
     ),
     excludeDependencies ++= Seq(
       // log4j brought in via uzaygezen is a pain for us
       ExclusionRule("log4j", "log4j")
-    )
+    ),
+    libraryDependencies := (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+        libraryDependencies.value ++ Seq(ansiColors212)
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        libraryDependencies.value ++ Seq(ansiColors211)
+    })
   )
 
 lazy val stac = project

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -11,15 +11,20 @@ import geotrellis.server.ogc.wmts._
 
 import cats.effect._
 import cats.implicits._
+
 import com.monovore.decline._
+
 import fs2._
+
 import org.http4s._
 import org.http4s.server._
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.{CORS, CORSConfig}
 import org.http4s.syntax.kleisli._
+
 import pureconfig._
 import pureconfig.generic.auto._
+
 import org.backuity.ansi.AnsiFormatter.FormattedHelper
 
 import scala.concurrent.duration._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,6 +68,9 @@ object Dependencies {
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.25"
   val slf4jSimple = "org.slf4j" % "slf4j-simple" % "1.7.25"
   val logback = "ch.qos.logback" % "logback-classic" % "1.1.7"
-  val ansiColors = "org.backuity" %% "ansi-interpolator" % "1.1.0" % Provided
   val shapeless = "com.chuusai" %% "shapeless" % shapelessVer
+
+  // This dependency differs between scala 2.11 and 2.12
+  val ansiColors211 = "org.backuity" %% "ansi-interpolator" % "1.1" % Provided
+  val ansiColors212 = "org.backuity" %% "ansi-interpolator" % "1.1.0" % Provided
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,4 @@ addSbtPlugin("org.scalaxb" % "sbt-scalaxb" % "1.7.0")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
+


### PR DESCRIPTION
The prior update for ansi colors on 2.12 worked well. Unfortunately, the updated dependency has a different version number for 2.11 and 2.12. This PR updates SBT to load the appropriate source depending on the scala version in a build