### PR TITLE
Add support for RGB and RGBA tiffs 

### DIFF
--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
@@ -88,7 +88,7 @@ class WmsView(wmsModel: WmsModel, serviceUrl: URL) extends LazyLogging {
               Invalid(errs)
           }.attempt flatMap {
             case Right(Valid((mbtile, hists))) => // success
-              val rendered = Render(mbtile, layer.style, wmsReq.format, hists)
+              val rendered = Render.singleband(mbtile, layer.style, wmsReq.format, hists)
               Ok(rendered)
             case Right(Invalid(errs)) => // maml-specific errors
               logger.debug(errs.toList.toString)

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -73,7 +73,7 @@ class WmtsView(wmtsModel: WmtsModel, serviceUrl: URL) extends LazyLogging {
                 Invalid(errs)
             }.attempt flatMap {
               case Right(Valid((mbtile, hists))) => // success
-                val rendered = Render(mbtile, layer.style, wmtsReq.format, hists)
+                val rendered = Render.singleband(mbtile, layer.style, wmtsReq.format, hists)
                 Ok(rendered)
               case Right(Invalid(errs)) => // maml-specific errors
                 logger.debug(errs.toList.toString)

--- a/ogc/src/main/scala/geotrellis/server/ogc/OutputFormat.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OutputFormat.scala
@@ -14,7 +14,7 @@ object OutputFormat {
   object Png {
     final val PngEncodingRx = """image/png(?:;encoding=(\w+))?""".r
 
-    def encodoingToString(enc: PngColorEncoding): String = enc match {
+    def encodingToString(enc: PngColorEncoding): String = enc match {
       case RgbaPngEncoding => "rgba"
       case GreyaPngEncoding => "greya"
       case _: RgbPngEncoding => "rgb"
@@ -34,7 +34,7 @@ object OutputFormat {
 
   case class Png(encoding: Option[PngColorEncoding]) extends OutputFormat {
     override def toString = encoding match {
-      case Some(e) => s"image/png;encoding=${Png.encodoingToString(e)}"
+      case Some(e) => s"image/png;encoding=${Png.encodingToString(e)}"
       case None => "image/png"
     }
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
@@ -3,14 +3,45 @@ package geotrellis.server.ogc
 import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._
-import geotrellis.raster.histogram._
 import geotrellis.raster.render.png._
+import geotrellis.raster.render._
+import geotrellis.raster.histogram._
 
 import scala.collection.mutable
 import scala.util.Try
 
 object Render {
-  def apply(mbtile: MultibandTile, maybeStyle: Option[OgcStyle], format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte] =
+  def rgb(mbtile: MultibandTile, maybeStyle: Option[OgcStyle], format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte] =
+    maybeStyle match {
+      case Some(style) =>
+        style.renderImage(mbtile, format, hists)
+      case None =>
+        format match {
+          case format: OutputFormat.Png =>
+            OutputFormat.Png(Some(RgbPngEncoding)).render(mbtile.color())
+          case OutputFormat.Jpg =>
+            mbtile.color().renderJpg.bytes
+          case format =>
+            throw new IllegalArgumentException(s"$format is not a valid output format")
+        }
+    }
+
+  def rgba(mbtile: MultibandTile, maybeStyle: Option[OgcStyle], format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte] =
+    maybeStyle match {
+      case Some(style) =>
+        style.renderImage(mbtile, format, hists)
+      case None =>
+        format match {
+          case format: OutputFormat.Png =>
+            OutputFormat.Png(Some(RgbaPngEncoding)).render(mbtile.color())
+          case OutputFormat.Jpg =>
+            mbtile.color().renderJpg.bytes
+          case format =>
+            throw new IllegalArgumentException(s"$format is not a valid output format")
+        }
+    }
+
+  def singleband(mbtile: MultibandTile, maybeStyle: Option[OgcStyle], format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte] =
     maybeStyle match {
       case Some(style) =>
         style.renderImage(mbtile, format, hists)
@@ -18,11 +49,10 @@ object Render {
         format match {
           case format: OutputFormat.Png =>
             format.render(mbtile.band(bandIndex = 0))
-
           case OutputFormat.Jpg =>
             mbtile.band(bandIndex = 0).renderJpg.bytes
-
-          case OutputFormat.GeoTiff => ??? // Implementation necessary
+          case format =>
+            throw new IllegalArgumentException(s"$format is not a valid output format")
         }
     }
 


### PR DESCRIPTION
This PR adds support for rendering imagery that might be broken up into 3 or 4 bands. In the 3 band case, the multiband tiff is expected to be RGB. In the 4 band case, RGB+Alpha.

Using `Render.singleband`:
![image](https://user-images.githubusercontent.com/1977405/61480561-37d46180-a964-11e9-9eea-67f3ad011bfa.png)

Using `Render.rgba`:
![image](https://user-images.githubusercontent.com/1977405/61480547-31de8080-a964-11e9-97ec-218d4d998512.png)
