### PR TITLE
Update STAC datamodel for label extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
+- *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
 
 ## [3.4.0] - 2019-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
 
 ## [3.4.0] - 2019-07-18

--- a/stac/src/main/scala/ItemCollection.scala
+++ b/stac/src/main/scala/ItemCollection.scala
@@ -1,0 +1,30 @@
+package geotrellis.server.stac
+
+import io.circe._
+
+case class ItemCollection(
+    _type: String = "FeatureCollection",
+    features: List[StacItem],
+    links: List[StacLink]
+)
+
+object ItemCollection {
+  implicit val encItemCollection: Encoder[ItemCollection] = Encoder.forProduct3(
+    "type",
+    "features",
+    "links"
+  )(
+    itemCollection =>
+      (
+        itemCollection._type,
+        itemCollection.features,
+        itemCollection.links
+      )
+  )
+
+  implicit val decItemCollection: Decoder[ItemCollection] = Decoder.forProduct3(
+    "type",
+    "features",
+    "links"
+  )(ItemCollection.apply _)
+}

--- a/stac/src/main/scala/StacItem.scala
+++ b/stac/src/main/scala/StacItem.scala
@@ -17,12 +17,11 @@ case class StacItem(
     collection: Option[String],
     properties: JsonObject
 ) {
-  val uri = assets
+
+  val cogUri: Option[String] = assets
     .filter(_._2._type == Some(`image/cog`))
     .values
-    .headOption map { _.href } getOrElse {
-    throw new IllegalArgumentException(s"Item $id does not have a cog asset")
-  }
+    .headOption map { _.href }
 }
 
 object StacItem {

--- a/stac/src/main/scala/StacItem.scala
+++ b/stac/src/main/scala/StacItem.scala
@@ -9,6 +9,8 @@ import io.circe._
 
 case class StacItem(
     id: String,
+    stacVersion: String,
+    stacExtensions: List[String],
     _type: String = "Feature",
     geometry: Geometry,
     bbox: TwoDimBbox,
@@ -26,8 +28,10 @@ case class StacItem(
 
 object StacItem {
 
-  implicit val encStacItem: Encoder[StacItem] = Encoder.forProduct8(
+  implicit val encStacItem: Encoder[StacItem] = Encoder.forProduct10(
     "id",
+    "stac_version",
+    "stac_extensions",
     "type",
     "geometry",
     "bbox",
@@ -39,6 +43,8 @@ object StacItem {
     item =>
       (
         item.id,
+        item.stacVersion,
+        item.stacExtensions,
         item._type,
         item.geometry,
         item.bbox.toList,
@@ -49,8 +55,10 @@ object StacItem {
       )
   )
 
-  implicit val decStacItem: Decoder[StacItem] = Decoder.forProduct8(
+  implicit val decStacItem: Decoder[StacItem] = Decoder.forProduct10(
     "id",
+    "stac_version",
+    "stac_extensions",
     "type",
     "geometry",
     "bbox",

--- a/stac/src/main/scala/StacLink.scala
+++ b/stac/src/main/scala/StacLink.scala
@@ -8,16 +8,18 @@ case class StacLink(
     href: String,
     rel: StacLinkType,
     _type: Option[StacMediaType],
-    title: Option[String]
+    title: Option[String],
+    labelExtAssets: List[String]
 )
 
 object StacLink {
-  implicit val encStacLink: Encoder[StacLink] = Encoder.forProduct4(
+  implicit val encStacLink: Encoder[StacLink] = Encoder.forProduct5(
     "href",
     "rel",
     "type",
-    "title"
-  )(link => (link.href, link.rel, link._type, link.title))
+    "title",
+    "label:assets"
+  )(link => (link.href, link.rel, link._type, link.title, link.labelExtAssets))
 
   implicit val decStacLink: Decoder[StacLink] = new Decoder[StacLink] {
     final def apply(c: HCursor) =
@@ -25,7 +27,8 @@ object StacLink {
         c.downField("href").as[String],
         c.downField("rel").as[StacLinkType],
         c.get[Option[StacMediaType]]("type"),
-        c.get[Option[String]]("title")
+        c.get[Option[String]]("title"),
+        c.get[List[String]]("label:assets")
       ).mapN(StacLink.apply _)
   }
 }

--- a/stac/src/main/scala/StacLinkType.scala
+++ b/stac/src/main/scala/StacLinkType.scala
@@ -12,6 +12,7 @@ case object Parent extends StacLinkType("parent")
 case object Child extends StacLinkType("child")
 case object Item extends StacLinkType("item")
 case object Items extends StacLinkType("items")
+case object Source extends StacLinkType("source")
 case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
   override def toString = s"$repr-$underlying"
 }
@@ -25,6 +26,7 @@ object StacLinkType {
     case "child" => Child
     case "item" => Item
     case "items" => Items
+    case "source" => Source
     case s => VendorLinkType(s)
   }
 

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -91,7 +91,8 @@ object Generators {
       nonEmptyStringGen,
       Gen.const(Self), // self link type is required by TMS reification
       Gen.option(mediaTypeGen),
-      Gen.option(nonEmptyStringGen)
+      Gen.option(nonEmptyStringGen),
+      Gen.nonEmptyListOf[String](arbitrary[String])
     ).mapN(StacLink.apply _)
 
   private def stacExtentGen: Gen[StacExtent] =

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -56,7 +56,8 @@ object Generators {
     Parent,
     Child,
     Item,
-    Items
+    Items,
+    Source
   )
 
   private def providerRoleGen: Gen[StacProviderRole] = Gen.oneOf(

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -123,6 +123,8 @@ object Generators {
   private def stacItemGen: Gen[StacItem] =
     (
       nonEmptyStringGen,
+      Gen.const("0.8.0-rc1"),
+      Gen.const(List.empty[String]),
       Gen.const("Feature"),
       rectangleGen,
       twoDimBboxGen,
@@ -157,11 +159,22 @@ object Generators {
       Gen.listOf(stacLinkGen)
     ).mapN(StacCollection.apply _)
 
-  implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary { mediaTypeGen }
+  private def itemCollectionGen: Gen[ItemCollection] =
+    (
+      Gen.const("FeatureCollection"),
+      Gen.listOf[StacItem](stacItemGen),
+      Gen.listOf[StacLink](stacLinkGen)
+    ).mapN(ItemCollection.apply _)
+
+  implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary {
+    mediaTypeGen
+  }
 
   implicit val arbLinkType: Arbitrary[StacLinkType] = Arbitrary { linkTypeGen }
 
-  implicit val arbProviderRole: Arbitrary[StacProviderRole] = Arbitrary { providerRoleGen }
+  implicit val arbProviderRole: Arbitrary[StacProviderRole] = Arbitrary {
+    providerRoleGen
+  }
 
   implicit val arbInstant: Arbitrary[Instant] = Arbitrary { instantGen }
 
@@ -175,5 +188,9 @@ object Generators {
 
   implicit val arbCollection: Arbitrary[StacCollection] = Arbitrary {
     stacCollectionGen
+  }
+
+  implicit val arbItemCollection: Arbitrary[ItemCollection] = Arbitrary {
+    itemCollectionGen
   }
 }

--- a/stac/src/test/scala/SerDeSpec.scala
+++ b/stac/src/test/scala/SerDeSpec.scala
@@ -43,6 +43,10 @@ class SerDeSpec extends FunSpec with Matchers with PropertyChecks {
       getPropTest[StacItem]
     }
 
+    it("item collections should round trip") {
+      getPropTest[ItemCollection]
+    }
+
     it("catalogs should round trip") {
       getPropTest[StacCatalog]
     }


### PR DESCRIPTION
## Overview

This PR relaxes the requirements on `StacItem`s so that they can be created without a COG asset and
adds the `Source` link type to `StacLinkTypes`. The `Source` link type is a part of the labeling extension, which is [included in STAC 0.8.0-rc1](https://github.com/radiantearth/stac-spec/blob/v0.8.0-rc1/CHANGELOG.md#added), and the relaxes requirement is part of making the datamodel usable for any purpose other than the demo that originally consumed it.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

- ~ci~ i saw a `.circleci` dir and thought that it meant there's ci. oops.
- `stac/test` -- shows that the new link type is fine
- `example/compile` shows that no type contracts were broken through the example

Closes #141
