### PR TITLE
Enable artifact publishing for opengis, ogc, and stac subprojects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
+                - feature/hmc/fix-artifact-publishing
       - "openjdk8-scala2.12.8_deploy":
           requires:
             - "openjdk8-scala2.12.8"
@@ -85,6 +86,7 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
+                - feature/hmc/fix-artifact-publishing
 
 jobs:
   "openjdk8-scala2.11.12":

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val root = project.in(file("."))
   .settings(moduleName := "root")
   .settings(commonSettings)
   .settings(noPublishSettings)
-  .aggregate(core, example, ogc, ogcExample, stac)
+  .aggregate(core, example, ogc, ogcExample, opengis, stac)
 
 lazy val core = project
   .settings(moduleName := "geotrellis-server-core")

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val opengis = project
   .enablePlugins(ScalaxbPlugin)
   .settings(moduleName := "geotrellis-server-opengis")
   .settings(commonSettings)
-  .settings(noPublishSettings)
+  .settings(publishSettings)
   .settings(
     libraryDependencies ++= Seq(
       scalaXml,
@@ -200,7 +200,7 @@ lazy val ogc = project
   .dependsOn(core, opengis)
   .settings(moduleName := "geotrellis-server-ogc")
   .settings(commonSettings)
-  .settings(noPublishSettings)
+  .settings(publishSettings)
   .settings(
     assemblyJarName in assembly := "geotrellis-server-ogc.jar",
     libraryDependencies ++= Seq(
@@ -259,7 +259,7 @@ lazy val ogcExample = (project in file("ogc-example"))
 lazy val stac = project
   .settings(moduleName := "geotrellis-server-stac")
   .settings(commonSettings)
-  .settings(noPublishSettings)
+  .settings(publishSettings)
   .settings(
     libraryDependencies ++= Seq(
       cats,


### PR DESCRIPTION
## Overview

In https://github.com/geotrellis/geotrellis-server/pull/138, the following subprojects configurations were updated to not publish artifacts:

- `opengis`
- `ogc`
- `stac`

This change set aims to enable artifact publishing for these projects.

### Checklist

- [ ] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Notes

This PR may now superscede https://github.com/geotrellis/geotrellis-server/pull/143.

## Testing Instructions

See:

- https://oss.sonatype.org/content/repositories/snapshots/com/azavea/geotrellis/
- https://app.circleci.com/jobs/github/geotrellis/geotrellis-server/59
- https://app.circleci.com/jobs/github/geotrellis/geotrellis-server/60

Fixes https://github.com/geotrellis/geotrellis-server/issues/146
