### PR TITLE
Make LayerHistogram more tolerant of param lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
+- Added `Collection` `rel` type to `StackLink` [#167](https://github.com/geotrellis/geotrellis-server/pull/167)
 ### Fixed
 - Fixed a bug in `LayerHistogram` sampling that prevented some histograms from being generated [\#167](https://github.com/geotrellis/geotrellis-server/pull/167)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
+### Fixed
+- Fixed a bug in `LayerHistogram` sampling that prevented some histograms from being generated [\#167](https://github.com/geotrellis/geotrellis-server/pull/167)
 
 ## [3.4.0] - 2019-07-18
 ### Added

--- a/core/src/main/scala/geotrellis/server/LayerHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/LayerHistogram.scala
@@ -25,74 +25,104 @@ object LayerHistogram extends LazyLogging {
   case class NoSuitableHistogramResolution(cells: Int) extends Throwable
   case class RequireIntersectingSources() extends Throwable
 
+  // Added so that we can get combine
+  implicit val extentSemigroup: Semigroup[Extent] =
+    new Semigroup[Extent] {
+      def combine(x: Extent, y: Extent): Extent = x.combine(y)
+    }
+
   // Provide IOs for both expression and params, get back a tile
   def apply[Param](
-    getExpression: IO[Expression],
-    getParams: IO[Map[String, Param]],
-    interpreter: Interpreter[IO],
-    maxCells: Int
+      getExpression: IO[Expression],
+      getParams: IO[Map[String, Param]],
+      interpreter: Interpreter[IO],
+      maxCells: Int
   )(
-    implicit reify: ExtentReification[Param],
-             extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
+      implicit reify: ExtentReification[Param],
+      extended: HasRasterExtents[Param],
+      contextShift: ContextShift[IO]
   ): IO[Interpreted[List[Histogram[Double]]]] =
     for {
-      params            <- getParams
-      rasterExtents     <- NEL.fromListUnsafe(params.values.toList)
-                             .map(_.rasterExtents)
-                             .parSequence
-                             .map(_.flatten)
-      intersection      <- IO { SampleUtils.intersectExtents(rasterExtents.map(_.extent))
-                                  .getOrElse(throw new RequireIntersectingSources()) }
-      _                 <- IO { logger.debug(s"[LayerHistogram] Intersection of provided layer extents calculated: $intersection") }
-      cellSize          <- IO { SampleUtils.chooseLargestCellSize(rasterExtents.map(_.cellSize)) }
-      _                 <- IO { logger.debug(s"[LayerHistogram] Largest cell size of provided layers calculated: $cellSize") }
-      mbtileForExtent   <- IO { LayerExtent(getExpression, getParams, interpreter) }
-      _                 <- IO { logger.debug(s"[LayerHistogram] calculating histogram from (approximately) ${intersection.area / (cellSize.width * cellSize.height)} cells") }
-      interpretedTile   <- mbtileForExtent(intersection, cellSize)
+      params <- getParams
+      rasterExtents <- NEL
+        .fromListUnsafe(params.values.toList)
+        .traverse(_.rasterExtents)
+        .map(_.flatten)
+      extents <- NEL
+        .fromListUnsafe(params.values.toList)
+        .traverse(_.rasterExtents.map(z => z.map(_.extent).reduce))
+      intersection <- IO {
+        SampleUtils
+          .intersectExtents(extents)
+          .getOrElse(throw new RequireIntersectingSources())
+      }
+      _ <- IO {
+        logger.debug(
+          s"[LayerHistogram] Intersection of provided layer extents calculated: $intersection"
+        )
+      }
+      cellSize <- IO {
+        SampleUtils.chooseLargestCellSize(rasterExtents.map(_.cellSize))
+      }
+      _ <- IO {
+        logger.debug(
+          s"[LayerHistogram] Largest cell size of provided layers calculated: $cellSize"
+        )
+      }
+      mbtileForExtent <- IO {
+        LayerExtent(getExpression, getParams, interpreter)
+      }
+      _ <- IO {
+        logger.debug(
+          s"[LayerHistogram] calculating histogram from (approximately) ${intersection.area / (cellSize.width * cellSize.height)} cells"
+        )
+      }
+      interpretedTile <- mbtileForExtent(intersection, cellSize)
     } yield {
       interpretedTile.map { mbtile =>
-        mbtile.bands.map { band  => StreamingHistogram.fromTile(band) }.toList
+        mbtile.bands.map { band =>
+          StreamingHistogram.fromTile(band)
+        }.toList
       }
     }
 
   def generateExpression[Param](
-    mkExpr: Map[String, Param] => Expression,
-    getParams: IO[Map[String, Param]],
-    interpreter: Interpreter[IO],
-    maxCells: Int
+      mkExpr: Map[String, Param] => Expression,
+      getParams: IO[Map[String, Param]],
+      interpreter: Interpreter[IO],
+      maxCells: Int
   )(
-    implicit reify: ExtentReification[Param],
-             extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
-  ) = apply[Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
-
+      implicit reify: ExtentReification[Param],
+      extended: HasRasterExtents[Param],
+      contextShift: ContextShift[IO]
+  ): IO[Interpreted[List[Histogram[Double]]]] =
+    apply[Param](getParams.map(mkExpr(_)), getParams, interpreter, maxCells)
 
   /** Provide an expression and expect arguments to fulfill its needs */
   def curried[Param](
-    expr: Expression,
-    interpreter: Interpreter[IO],
-    maxCells: Int
+      expr: Expression,
+      interpreter: Interpreter[IO],
+      maxCells: Int
   )(
-    implicit reify: ExtentReification[Param],
-             extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
+      implicit reify: ExtentReification[Param],
+      extended: HasRasterExtents[Param],
+      contextShift: ContextShift[IO]
   ): (Map[String, Param]) => IO[Interpreted[List[Histogram[Double]]]] =
     (paramMap: Map[String, Param]) => {
       apply[Param](IO.pure(expr), IO.pure(paramMap), interpreter, maxCells)
     }
 
-
   /** The identity endpoint (for simple display of raster) */
   def identity[Param](
-    param: Param,
-    maxCells: Int
+      param: Param,
+      maxCells: Int
   )(
-    implicit reify: ExtentReification[Param],
-             extended: HasRasterExtents[Param],
-             contextShift: ContextShift[IO]
-  ) = {
-    val eval = curried(RasterVar("identity"), ConcurrentInterpreter.DEFAULT, maxCells)
+      implicit reify: ExtentReification[Param],
+      extended: HasRasterExtents[Param],
+      contextShift: ContextShift[IO]
+  ): IO[Interpreted[List[Histogram[Double]]]] = {
+    val eval =
+      curried(RasterVar("identity"), ConcurrentInterpreter.DEFAULT, maxCells)
     eval(Map("identity" -> param))
   }
 

--- a/stac/src/main/scala/StacLinkType.scala
+++ b/stac/src/main/scala/StacLinkType.scala
@@ -13,6 +13,7 @@ case object Child extends StacLinkType("child")
 case object Item extends StacLinkType("item")
 case object Items extends StacLinkType("items")
 case object Source extends StacLinkType("source")
+case object Collection extends StacLinkType("collection")
 case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
   override def toString = s"$repr-$underlying"
 }
@@ -20,14 +21,15 @@ case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
 object StacLinkType {
 
   private def fromString(s: String): StacLinkType = s.toLowerCase match {
-    case "self" => Self
-    case "root" => StacRoot
-    case "parent" => Parent
-    case "child" => Child
-    case "item" => Item
-    case "items" => Items
-    case "source" => Source
-    case s => VendorLinkType(s)
+    case "self"       => Self
+    case "root"       => StacRoot
+    case "parent"     => Parent
+    case "child"      => Child
+    case "item"       => Item
+    case "items"      => Items
+    case "source"     => Source
+    case "collection" => Collection
+    case s            => VendorLinkType(s)
   }
 
   implicit val encStacLinkType: Encoder[StacLinkType] =


### PR DESCRIPTION
## Overview

This solves a bug where params that had lists of values
themselves could end up falsely saying that their raster
extents did not intersect (even though we're 100 percent
sure they do) and then failing to produce a
histogram for the application.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/898060/67575699-20e39f00-f70b-11e9-88ef-377fb9a72c60.png)


### Notes

I think this is another example of where https://github.com/geotrellis/geotrellis-server/issues/72 being closed would have given us a few escape hatches, but ultimately this still was probably a bug here.

## Testing Instructions

Unfortunately I don't have good testing instructions outside of a Raster Foundry environment. But once this branch is published local and you've updated your dependencies in RF this is testable by viewing/creating any multi-scene analysis.

Closes #165 
