### PR TITLE
Add stac link types for OGC link relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Enable artifact publishing for `opengis`, `ogc`, and `stac` subprojects [\#147](https://github.com/geotrellis/geotrellis-server/pull/147)
+- Included more link types based on OGC Features API [\#176](https://github.com/geotrellis/geotrellis-server/pull/176)
 ### Changed
 - *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)

--- a/stac/src/main/scala/StacLinkType.scala
+++ b/stac/src/main/scala/StacLinkType.scala
@@ -21,6 +21,8 @@ case object Next extends StacLinkType("next")
 case object Prev extends StacLinkType("prev")
 case object ServiceDesc extends StacLinkType("service-desc")
 case object ServiceDoc extends StacLinkType("service-doc")
+case object Conformance extends StacLinkType("conformance")
+case object Data extends StacLinkType("data")
 case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
   override def toString = s"$repr-$underlying"
 }
@@ -42,6 +44,8 @@ object StacLinkType {
     case "prev"         => Prev
     case "service-desc" => ServiceDesc
     case "service-doc"  => ServiceDoc
+    case "conformance"  => Conformance
+    case "data"         => Data
     case s              => VendorLinkType(s)
   }
 

--- a/stac/src/main/scala/StacLinkType.scala
+++ b/stac/src/main/scala/StacLinkType.scala
@@ -15,6 +15,12 @@ case object Items extends StacLinkType("items")
 case object Source extends StacLinkType("source")
 case object Collection extends StacLinkType("collection")
 case object License extends StacLinkType("license")
+case object Alternate extends StacLinkType("alternate")
+case object DescribedBy extends StacLinkType("describedBy")
+case object Next extends StacLinkType("next")
+case object Prev extends StacLinkType("prev")
+case object ServiceDesc extends StacLinkType("service-desc")
+case object ServiceDoc extends StacLinkType("service-doc")
 case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
   override def toString = s"$repr-$underlying"
 }
@@ -22,16 +28,21 @@ case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
 object StacLinkType {
 
   private def fromString(s: String): StacLinkType = s.toLowerCase match {
-    case "self"       => Self
-    case "root"       => StacRoot
-    case "parent"     => Parent
-    case "child"      => Child
-    case "item"       => Item
-    case "items"      => Items
-    case "source"     => Source
-    case "collection" => Collection
-    case "license"    => License
-    case s            => VendorLinkType(s)
+    case "self"         => Self
+    case "root"         => StacRoot
+    case "parent"       => Parent
+    case "child"        => Child
+    case "item"         => Item
+    case "items"        => Items
+    case "alternate"    => Alternate
+    case "collection"   => Collection
+    case "describedBy"  => DescribedBy
+    case "next"         => Next
+    case "license"      => License
+    case "prev"         => Prev
+    case "service-desc" => ServiceDesc
+    case "service-doc"  => ServiceDoc
+    case s              => VendorLinkType(s)
   }
 
   implicit val encStacLinkType: Encoder[StacLinkType] =

--- a/stac/src/main/scala/StacLinkType.scala
+++ b/stac/src/main/scala/StacLinkType.scala
@@ -38,7 +38,7 @@ object StacLinkType {
     case "items"        => Items
     case "alternate"    => Alternate
     case "collection"   => Collection
-    case "describedBy"  => DescribedBy
+    case "describedby"  => DescribedBy
     case "next"         => Next
     case "license"      => License
     case "prev"         => Prev
@@ -46,6 +46,7 @@ object StacLinkType {
     case "service-doc"  => ServiceDoc
     case "conformance"  => Conformance
     case "data"         => Data
+    case "source"       => Source
     case s              => VendorLinkType(s)
   }
 

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -66,7 +66,9 @@ object Generators {
     Next,
     Prev,
     ServiceDesc,
-    ServiceDoc
+    ServiceDoc,
+    Conformance,
+    Data
   )
 
   private def providerRoleGen: Gen[StacProviderRole] = Gen.oneOf(

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -60,7 +60,13 @@ object Generators {
     Items,
     Source,
     Collection,
-    License
+    License,
+    Alternate,
+    DescribedBy,
+    Next,
+    Prev,
+    ServiceDesc,
+    ServiceDoc
   )
 
   private def providerRoleGen: Gen[StacProviderRole] = Gen.oneOf(


### PR DESCRIPTION
## Overview

This PR adds some new StacLinkTypes from http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_link_relations. It supports work in https://github.com/azavea/franklin.

## Notes

`stac` subproject in Scala 2.11 doesn't compile right now -- that wasn't introduced here and I'm opening a separate issue to fix it

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

- tests, check for typos from the link types in the link

Closes azavea/franklin#8