### PR TITLE
Don't choose name so likely to collide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
 - Added `Collection` `rel` type to `StackLink` [#167](https://github.com/geotrellis/geotrellis-server/pull/167)
+- Fixed collision with `decoder` method name in `circe-fs2` [#178](https://github.com/geotrellis/geotrellis-server/pull/178)
 ### Fixed
 - Fixed a bug in `LayerHistogram` sampling that prevented some histograms from being generated [\#167](https://github.com/geotrellis/geotrellis-server/pull/167)
 

--- a/stac/src/main/scala/StacLink.scala
+++ b/stac/src/main/scala/StacLink.scala
@@ -28,7 +28,15 @@ object StacLink {
         c.downField("rel").as[StacLinkType],
         c.get[Option[StacMediaType]]("type"),
         c.get[Option[String]]("title"),
-        c.get[List[String]]("label:assets")
-      ).mapN(StacLink.apply _)
+        c.get[Option[List[String]]]("label:assets")
+      ).mapN(
+        (
+            href: String,
+            rel: StacLinkType,
+            _type: Option[StacMediaType],
+            title: Option[String],
+            assets: Option[List[String]]
+        ) => StacLink(href, rel, _type, title, assets getOrElse List.empty)
+      )
   }
 }

--- a/stac/src/main/scala/package.scala
+++ b/stac/src/main/scala/package.scala
@@ -97,13 +97,13 @@ package object stac {
 
   }
 
-  implicit val encoderTemporalExtent: Encoder[TemporalExtent] =
+  implicit val encodeTemporalExtent: Encoder[TemporalExtent] =
     new Encoder[TemporalExtent] {
       final def apply(t: TemporalExtent): Json = {
         t.value.map(x => x.asJson).asJson
       }
     }
-  implicit val decoder: Decoder[TemporalExtent] =
+  implicit val decodeTemporalExtent: Decoder[TemporalExtent] =
     Decoder.decodeList[Option[Instant]].emap {
       case l =>
         RefType.applyRef[TemporalExtent](l)

--- a/stac/src/test/scala/SerDeSpec.scala
+++ b/stac/src/test/scala/SerDeSpec.scala
@@ -78,4 +78,9 @@ class SerDeSpec
     }
   }
 
+  it("should ignore optional fields") {
+    val link = decode[StacLink]("""{"href":"s3://foo/item.json","rel":"item"}""")
+    link map { _.labelExtAssets } shouldBe Right(List.empty[String])
+  }
+
 }


### PR DESCRIPTION
## Overview

This PR makes it so that a specific decoder doesn't collide with the `decoder` pipe in circe-fs2. It also makes the `label:assets` field optional (not "must be there but can be empty list," but actually optional) in STAC items.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

- serdespec