### PR TITLE
Refactor Bbox, Remove Public/Private Stac Collection, and Fix 2.11 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Included more link types based on OGC Features API [\#176](https://github.com/geotrellis/geotrellis-server/pull/176)
 ### Changed
 - *Breaking* Update StacItem and StacLinkType compliance and better ergonomics with labeling extension [\#145](https://github.com/geotrellis/geotrellis-server/pull/145)
+- *Breaking* Changed Bbox to an ADT [\#180](https://github.com/geotrellis/geotrellis-server/pull/180)
 - Publish to Sonatype Nexus via CircleCI [#138](https://github.com/geotrellis/geotrellis-server/pull/138)
 - Added `Collection` `rel` type to `StackLink` [#167](https://github.com/geotrellis/geotrellis-server/pull/167)
 - Fixed collision with `decoder` method name in `circe-fs2` [#178](https://github.com/geotrellis/geotrellis-server/pull/178)

--- a/stac/src/main/scala/Bbox.scala
+++ b/stac/src/main/scala/Bbox.scala
@@ -1,0 +1,82 @@
+package geotrellis.server.stac
+
+import io.circe._
+import io.circe.syntax._
+import cats.implicits._
+
+sealed trait Bbox {
+  val toList: List[Double]
+}
+case class TwoDimBbox(xmin: Double, ymin: Double, xmax: Double, ymax: Double)
+  extends Bbox {
+  val toList = List(xmin, ymin, xmax, ymax)
+}
+case class ThreeDimBbox(
+                         xmin: Double,
+                         ymin: Double,
+                         zmin: Double,
+                         xmax: Double,
+                         ymax: Double,
+                         zmax: Double
+                       ) extends Bbox {
+  val toList = List(xmin, ymin, zmin, xmax, ymax, zmax)
+}
+
+object TwoDimBbox {    implicit val decoderTwoDBox: Decoder[TwoDimBbox] =
+  Decoder.decodeList[Double].emap {
+    case twodim if twodim.length == 4 =>
+      Either.right(TwoDimBbox(twodim(0), twodim(1), twodim(2), twodim(3)))
+    case other =>
+      Either.left(
+        s"Incorrect number of values for 2d box - found ${other.length}, expected 4"
+      )
+  }
+
+
+  implicit val encoderTwoDimBbox: Encoder[TwoDimBbox] =
+    new Encoder[TwoDimBbox] {
+      def apply(a: TwoDimBbox): Json = a.toList.asJson
+    }
+
+}
+object ThreeDimBbox {
+
+  implicit val decoderThreeDimBox: Decoder[ThreeDimBbox] =
+    Decoder.decodeList[Double].emap {
+      case threeDim if threeDim.length == 6 =>
+        Either.right(
+          ThreeDimBbox(
+            threeDim(0),
+            threeDim(1),
+            threeDim(2),
+            threeDim(3),
+            threeDim(4),
+            threeDim(5)
+          )
+        )
+      case other =>
+        Either.left(
+          s"Incorrect number of values for 2d box - found ${other.length}, expected 4"
+        )
+    }
+
+  implicit val encoderThreeDimBbox: Encoder[ThreeDimBbox] =
+    new Encoder[ThreeDimBbox] {
+      def apply(a: ThreeDimBbox): Json = a.toList.asJson
+    }
+
+}
+object Bbox {
+
+  implicit val encoderBbox: Encoder[Bbox] = new Encoder[Bbox] {
+    def apply(a: Bbox): Json = a match {
+      case two: TwoDimBbox     => two.asJson
+      case three: ThreeDimBbox => three.asJson
+    }
+  }
+
+  implicit val decoderBbox
+  : Decoder[Bbox] = Decoder[TwoDimBbox].widen or Decoder[ThreeDimBbox].widen
+
+
+}

--- a/stac/src/main/scala/Bbox.scala
+++ b/stac/src/main/scala/Bbox.scala
@@ -3,23 +3,26 @@ package geotrellis.server.stac
 import io.circe._
 import io.circe.syntax._
 import cats.implicits._
+import geotrellis.vector.Extent
 
 sealed trait Bbox {
   val toList: List[Double]
+  val toExtent: Extent
 }
 case class TwoDimBbox(xmin: Double, ymin: Double, xmax: Double, ymax: Double)
   extends Bbox {
   val toList = List(xmin, ymin, xmax, ymax)
+  val toExtent = Extent(xmin, ymin, xmax, ymax)
 }
 case class ThreeDimBbox(
-                         xmin: Double,
-                         ymin: Double,
-                         zmin: Double,
-                         xmax: Double,
-                         ymax: Double,
-                         zmax: Double
-                       ) extends Bbox {
+    xmin: Double,
+    ymin: Double,
+    zmin: Double,
+    xmax: Double,
+    ymax: Double,
+    zmax: Double) extends Bbox {
   val toList = List(xmin, ymin, zmin, xmax, ymax, zmax)
+  val toExtent = Extent(xmin, ymin, xmax, ymax)
 }
 
 object TwoDimBbox {    implicit val decoderTwoDBox: Decoder[TwoDimBbox] =

--- a/stac/src/main/scala/StacCollection.scala
+++ b/stac/src/main/scala/StacCollection.scala
@@ -6,53 +6,24 @@ import io.circe._
 import io.circe.syntax._
 import io.circe.refined._
 
-sealed trait StacCollection {
-  val stacVersion: String
-  val id: String
-  val title: Option[String]
-  val description: String
-  val keywords: List[String]
-  val version: String
-  val license: StacLicense
-  val providers: List[StacProvider]
-  val extent: StacExtent
-  val properties: JsonObject
-  val links: List[StacLink]
-}
 
-case class PublicStacCollection(
+final case class StacCollection(
     stacVersion: String,
     id: String,
     title: Option[String],
     description: String,
     keywords: List[String],
     version: String,
-    license: SPDX,
+    license: StacLicense,
     providers: List[StacProvider],
     extent: StacExtent,
     properties: JsonObject,
     links: List[StacLink]
-) extends StacCollection
-
-case class ProprietaryStacCollection(
-    stacVersion: String,
-    id: String,
-    title: Option[String],
-    description: String,
-    keywords: List[String],
-    version: String,
-    license: Proprietary,
-    providers: List[StacProvider],
-    extent: StacExtent,
-    properties: JsonObject,
-    linksWithLicenseLink: StacLinksWithLicense
-) extends StacCollection {
-  val links: List[StacLink] = linksWithLicenseLink.value
-}
+)
 
 object StacCollection {
 
-  implicit val encoderPublicCollection: Encoder[PublicStacCollection] =
+  implicit val encoderStacCollection: Encoder[StacCollection] =
     Encoder.forProduct11(
       "stac_version",
       "id",
@@ -82,46 +53,7 @@ object StacCollection {
         )
     )
 
-  implicit val encoderProprietaryCollection
-      : Encoder[ProprietaryStacCollection] =
-    Encoder.forProduct11(
-      "stac_version",
-      "id",
-      "title",
-      "description",
-      "keywords",
-      "version",
-      "license",
-      "providers",
-      "extent",
-      "properties",
-      "links"
-    )(
-      collection =>
-        (
-          collection.stacVersion,
-          collection.id,
-          collection.title,
-          collection.description,
-          collection.keywords,
-          collection.version,
-          collection.license,
-          collection.providers,
-          collection.extent,
-          collection.properties,
-          collection.links
-        )
-    )
-
-  implicit val encodeStacCollection: Encoder[StacCollection] =
-    Encoder.instance {
-      case public: PublicStacCollection =>
-        public.asJson
-      case proprietary: ProprietaryStacCollection =>
-        proprietary.asJson
-    }
-
-  implicit val decoderPublicStacCollection: Decoder[PublicStacCollection] =
+  implicit val decoderStacCollection: Decoder[StacCollection] =
     Decoder.forProduct11(
       "stac_version",
       "id",
@@ -142,13 +74,13 @@ object StacCollection {
           description: String,
           keywords: Option[List[String]],
           version: Option[String],
-          license: SPDX,
+          license: StacLicense,
           providers: Option[List[StacProvider]],
           extent: StacExtent,
           properties: Option[JsonObject],
           links: List[StacLink]
       ) =>
-        PublicStacCollection(
+        StacCollection(
           stacVersion,
           id,
           title,
@@ -162,50 +94,4 @@ object StacCollection {
           links
         )
     )
-
-  implicit val decoderProprietaryStacCollection
-      : Decoder[ProprietaryStacCollection] =
-    Decoder.forProduct11(
-      "stac_version",
-      "id",
-      "title",
-      "description",
-      "keywords",
-      "version",
-      "license",
-      "providers",
-      "extent",
-      "properties",
-      "links"
-    )(
-      (
-          stacVersion: String,
-          id: String,
-          title: Option[String],
-          description: String,
-          keywords: Option[List[String]],
-          version: Option[String],
-          license: Proprietary,
-          providers: Option[List[StacProvider]],
-          extent: StacExtent,
-          properties: Option[JsonObject],
-          linksWithLicenseLink: StacLinksWithLicense
-      ) =>
-        ProprietaryStacCollection(
-          stacVersion,
-          id,
-          title,
-          description,
-          keywords getOrElse List.empty,
-          version getOrElse "0.0.0-alpha",
-          license,
-          providers getOrElse List.empty,
-          extent,
-          properties getOrElse JsonObject.fromMap(Map.empty),
-          linksWithLicenseLink
-        )
-    )
-
-  implicit val decoderStacCollection: Decoder[StacCollection] =
-    Decoder[ProprietaryStacCollection].widen or Decoder[PublicStacCollection].widen
 }

--- a/stac/src/main/scala/StacItem.scala
+++ b/stac/src/main/scala/StacItem.scala
@@ -47,7 +47,7 @@ object StacItem {
         item.stacExtensions,
         item._type,
         item.geometry,
-        item.bbox.toList,
+        item.bbox,
         item.links,
         item.assets,
         item.collection,

--- a/stac/src/main/scala/package.scala
+++ b/stac/src/main/scala/package.scala
@@ -97,48 +97,8 @@ package object stac {
 
   }
 
-  implicit val encodeTemporalExtent: Encoder[TemporalExtent] =
-    new Encoder[TemporalExtent] {
-      final def apply(t: TemporalExtent): Json = {
-        t.value.map(x => x.asJson).asJson
-      }
-    }
-  implicit val decodeTemporalExtent: Decoder[TemporalExtent] =
-    Decoder.decodeList[Option[Instant]].emap {
-      case l =>
-        RefType.applyRef[TemporalExtent](l)
-    }
+  object Implicits {
 
-  type TwoDimBbox = Double :: Double :: Double :: Double :: HNil
-
-  object TwoDimBbox {
-    def apply(
-        xmin: Double,
-        ymin: Double,
-        xmax: Double,
-        ymax: Double
-    ): TwoDimBbox =
-      xmin :: ymin :: xmax :: ymax :: HNil
-  }
-
-  type ThreeDimBbox =
-    Double :: Double :: Double :: Double :: Double :: Double :: HNil
-
-  object ThreeDimBbox {
-    def apply(
-        xmin: Double,
-        ymin: Double,
-        zmin: Double,
-        xmax: Double,
-        ymax: Double,
-        zmax: Double
-    ): ThreeDimBbox =
-      xmin :: ymin :: zmin :: xmax :: ymax :: zmax :: HNil
-  }
-
-  type Bbox = TwoDimBbox :+: ThreeDimBbox :+: CNil
-
-  object Implicits extends CoproductInstances {
 
     // Stolen straight from circe docs
     implicit val decodeInstant: Decoder[Instant] = Decoder.decodeString.emap {
@@ -151,6 +111,18 @@ package object stac {
     implicit val encodeInstant: Encoder[Instant] =
       Encoder.encodeString.contramap[Instant](_.toString)
 
+    implicit val encodeTemporalExtent =
+      new Encoder[TemporalExtent] {
+        final def apply(t: TemporalExtent): Json = {
+          t.value.map(x => x.asJson).asJson
+        }
+      }
+    implicit val decodeTemporalExtent =
+      Decoder.decodeList[Option[Instant]].emap {
+        case l =>
+          RefType.applyRef[TemporalExtent](l)
+      }
+
     implicit val geometryDecoder: Decoder[Geometry] = Decoder[Json] map { js =>
       js.spaces4.parseGeoJson[Geometry]
     }
@@ -162,38 +134,6 @@ package object stac {
           case Left(e)   => throw e
         }
       }
-    }
-
-    implicit val enc2DBbox: Encoder[TwoDimBbox] = new Encoder[TwoDimBbox] {
-      def apply(box: TwoDimBbox) = Encoder[List[Double]].apply(box.toList)
-    }
-
-    implicit val enc3DBbox: Encoder[ThreeDimBbox] = new Encoder[ThreeDimBbox] {
-      def apply(box: ThreeDimBbox) = Encoder[List[Double]].apply(box.toList)
-    }
-
-    // These `new Exception(message)` underlying exceptions aren't super helpful, but the wrapping
-    // ParsingFailure should be sufficient to match on for any client that needs to do so
-    implicit val dec2DBbox: Decoder[TwoDimBbox] = Decoder[List[Double]] map {
-      case nums if nums.length == 4 =>
-        nums(0) :: nums(1) :: nums(2) :: nums(3) :: HNil
-      case nums if nums.length > 4 =>
-        val message = s"Too many values for 2D bbox: $nums"
-        throw new ParsingFailure(message, new Exception(message))
-      case nums if nums.length < 3 =>
-        val message = s"Too few values for 2D bbox: $nums"
-        throw new ParsingFailure(message, new Exception(message))
-    }
-
-    implicit val dec3DBbox: Decoder[ThreeDimBbox] = Decoder[List[Double]] map {
-      case nums if nums.length == 6 =>
-        nums(0) :: nums(1) :: nums(2) :: nums(3) :: nums(4) :: nums(5) :: HNil
-      case nums if nums.length > 6 =>
-        val message = s"Too many values for 3D bbox: $nums"
-        throw new ParsingFailure(message, new Exception(message))
-      case nums if nums.length < 6 =>
-        val message = s"Too few values for 3D bbox: $nums"
-        throw new ParsingFailure(message, new Exception(message))
     }
 
     implicit val decTimeRange

--- a/stac/src/main/scala/package.scala
+++ b/stac/src/main/scala/package.scala
@@ -17,41 +17,6 @@ import shapeless._
 
 package object stac {
 
-  case class LicenseLink()
-
-  object LicenseLink {
-    implicit def validateLicenseLink: Validate.Plain[StacLink, LicenseLink] =
-      Validate.fromPredicate(
-        l =>
-          l.rel match {
-            case License => true
-            case _       => false
-          },
-        t => s"Not a License Link: ${t.rel}",
-        LicenseLink()
-      )
-  }
-
-  type StacLinksWithLicense = List[StacLink] Refined Exists[LicenseLink]
-  object StacLinksWithLicense
-      extends RefinedTypeOps[StacLinksWithLicense, List[StacLink]] {
-    def fromStacLinkWithLicense(
-        links: List[StacLink],
-        href: String,
-        stacMediaType: Option[StacMediaType],
-        title: Option[String]
-    ): StacLinksWithLicense = {
-      val licenseLink = StacLink(
-        href,
-        License,
-        stacMediaType,
-        title,
-        List.empty[String]
-      )
-      StacLinksWithLicense.unsafeFrom(licenseLink :: links)
-    }
-  }
-
   type SpdxId = String Refined ValidSpdxId
   object SpdxId extends RefinedTypeOps[SpdxId, String]
 
@@ -98,7 +63,6 @@ package object stac {
   }
 
   object Implicits {
-
 
     // Stolen straight from circe docs
     implicit val decodeInstant: Decoder[Instant] = Decoder.decodeString.emap {

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -95,17 +95,8 @@ object Generators {
       arbitrary[Double]
     ).mapN(ThreeDimBbox.apply _)
 
-//  This breaks test, the decoder can't handle it - commenting out for now
-//  The problem is that we're throwing an exception in the first decoder we're trying
-//  to accumulate possibilities from, so we can't try the later decoders. Not sure how
-//  to fix.
-//  private def bboxGen: Gen[Bbox] =
-//    Gen.oneOf(twoDimBboxGen map { Coproduct[Bbox](_) }, threeDimBboxGen map {
-//      Coproduct[Bbox](_)
-//    })
-//
-
-  private def bboxGen: Gen[Bbox] = twoDimBboxGen map { Coproduct[Bbox](_) }
+  private def bboxGen: Gen[Bbox] =
+    Gen.oneOf(twoDimBboxGen.widen, threeDimBboxGen.widen)
 
   private def stacLinkGen: Gen[StacLink] =
     (

--- a/stac/src/test/scala/Generators.scala
+++ b/stac/src/test/scala/Generators.scala
@@ -85,6 +85,10 @@ object Generators {
   private def spdxGen: Gen[SPDX] =
     arbitrary[SpdxLicense] map (license => SPDX(SpdxId.unsafeFrom(license.id)))
 
+  private def proprietaryGen: Gen[Proprietary] = Gen.const(Proprietary())
+
+  private def stacLicenseGen: Gen[StacLicense] = Gen.oneOf(spdxGen, proprietaryGen)
+
   private def threeDimBboxGen: Gen[ThreeDimBbox] =
     (
       arbitrary[Double],
@@ -175,12 +179,12 @@ object Generators {
       nonEmptyStringGen,
       Gen.listOf(nonEmptyStringGen),
       nonEmptyStringGen,
-      spdxGen,
+      stacLicenseGen,
       Gen.listOf(stacProviderGen),
       stacExtentGen,
       Gen.const(JsonObject.fromMap(Map.empty)),
       Gen.listOf(stacLinkGen)
-    ).mapN(PublicStacCollection.apply _)
+    ).mapN(StacCollection.apply _)
 
   private def itemCollectionGen: Gen[ItemCollection] =
     (

--- a/stac/src/test/scala/SerDeSpec.scala
+++ b/stac/src/test/scala/SerDeSpec.scala
@@ -11,6 +11,8 @@ import org.scalacheck.Arbitrary
 import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import java.time.Instant
+import cats.syntax._
+import cats.implicits._
 
 import com.typesafe.scalalogging.LazyLogging
 
@@ -79,7 +81,8 @@ class SerDeSpec
   }
 
   it("should ignore optional fields") {
-    val link = decode[StacLink]("""{"href":"s3://foo/item.json","rel":"item"}""")
+    val link =
+      decode[StacLink]("""{"href":"s3://foo/item.json","rel":"item"}""")
     link map { _.labelExtAssets } shouldBe Right(List.empty[String])
   }
 }


### PR DESCRIPTION
## Overview

This refactors Bbox to be a sealed trait, re-enables both 2d and 3d bounding boxes in tests, fixes the 2.11 builds, and also removes the distinction between public/private collections since that original split was based on my misreading of the specification.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

- Run tests

Closes #177 
