### PR TITLE
Bump MAML version up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Included split dependencies a la GeoTrellis 3.2 for cats ecosystem libraries [\#184](https://github.com/geotrellis/geotrellis-server/pull/184)
 - Dropped WCS 1.0.0 support
+- Updated MAML up to 0.6.0 [#199](https://github.com/geotrellis/geotrellis-server/pull/199)
 
 ### Fixed
 - Missing `<ows:Title>` and `<ows:Abstract>` elements in WCS GetCapabilities response [#114](https://github.com/geotrellis/geotrellis-server/issues/114) 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   val kamonPrometheus = "io.kamon" %% "kamon-prometheus" % "1.0.0"
   val kamonSysMetrics = "io.kamon" %% "kamon-system-metrics" % "1.0.0"
   val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0"
-  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.5.1-2-g0baee67-SNAPSHOT"
+  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0"
   val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.10.2"
   val refined = "eu.timepit" %% "refined" % refinedVer
   val scaffeine = "com.github.blemale" %% "scaffeine" % "2.6.0"


### PR DESCRIPTION
## Overview

This PR updates MAML version from some SNAPSHOT version up to the stable 0.6.0 release.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

Related to https://github.com/geotrellis/geotrellis-server/issues/194
