### PR TITLE
Add support for colormap with floating point keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated MAML up to 0.6.0 [#199](https://github.com/geotrellis/geotrellis-server/pull/199)
 
 ### Fixed
+- Non-integer (floating point) ColorMap keys now work with or without being quoted [#187](https://github.com/geotrellis/geotrellis-server/issues/187)
 - Missing `<ows:Title>` and `<ows:Abstract>` elements in WCS GetCapabilities response [#114](https://github.com/geotrellis/geotrellis-server/issues/114) 
 - Layer definition elements unused in WMS GetCapabilities response [#115](https://github.com/geotrellis/geotrellis-server/issues/115)
 - Bad assembly strategy [#142](https://github.com/geotrellis/geotrellis-server/issues/142)

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -222,6 +222,12 @@ layers = {
                 type = "colorrampconf"
                 colors = ${color-ramps.red-to-blue}
                 stops = 64
+            },
+            {
+                name = "ndvi"
+                title = "NDVI colors (for demonstration only)"
+                type = "colormapconf"
+                color-map = ${color-maps.ndvi}
             }
         ]
     }
@@ -368,5 +374,22 @@ color-maps = {
     2000: 0xA59678FF,
     2500: 0xD7D7D7FF,
     3000: 0xFFFFFFFF
+  }
+  "ndvi": {
+    -1.0: 0x1947B0FF,
+    -0.7: 0x3961B7FF,
+    -0.5: 0x5A7BBFFF,
+    -0.4: 0x7B95C6FF,
+    -0.3: 0x9CB0CEFF,
+    -0.2: 0xBDCAD5FF,
+    -0.1: 0xDEE4DDFF,
+    "0": 0xFFFFE5FF,
+    "0.1": 0xDAE4CAFF,
+    "0.2": 0xB6C9AFFF,
+    "0.3": 0x91AF94FF,
+    "0.4": 0x6D9479FF,
+    "0.5": 0x487A5EFF,
+    "0.7": 0x245F43FF,
+    "1.0": 0x004529FF
   }
 }


### PR DESCRIPTION
## Overview

This PR adds support for `ColorMap` with non-integer keys by looking for an incorrectly parsed value. If incorrectly parsed, the non-integer key is reconstructed. This appears to be safe because this code path is only exercised when we're attempting to decode a `ColorMap` and not more generally as HOCON is being parsed


### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

The example configuration now includes a set of floating point keyed `ColorMap`s

## Testing Instructions

- Run the example OGC server

Closes #187 
