### PR TITLE
Fix interpolation w/ duplicate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated MAML up to 0.6.0 [#199](https://github.com/geotrellis/geotrellis-server/pull/199)
 
 ### Fixed
+- Fixed color interpolation bug related to constructing a range when the step is 0 [#111](https://github.com/geotrellis/geotrellis-server/issues/111)
 - Non-integer (floating point) ColorMap keys now work with or without being quoted [#187](https://github.com/geotrellis/geotrellis-server/issues/187)
 - Missing `<ows:Title>` and `<ows:Abstract>` elements in WCS GetCapabilities response [#114](https://github.com/geotrellis/geotrellis-server/issues/114) 
 - Layer definition elements unused in WMS GetCapabilities response [#115](https://github.com/geotrellis/geotrellis-server/issues/115)

--- a/ogc-example/src/test/scala/geotrellis/server/ogc/RenderSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/ogc/RenderSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc
+
+import geotrellis.server.extent.SampleUtils
+
+import geotrellis.raster._
+import geotrellis.vector._
+import com.azavea.maml.error._
+import cats._
+import cats.effect._
+import cats.data.{NonEmptyList => NEL}
+import cats.implicits._
+
+import org.scalatest._
+
+import scala.util.Random
+import scala.concurrent.ExecutionContext
+
+
+class RenderSpec extends FunSpec with Matchers {
+  implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
+
+  describe("Linear Interpolation") {
+    it("should not throw when duplicate breaks are encountered") {
+      Render.linearInterpolationBreaks(Array(0, 0, 80), 255)
+    }
+  }
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
@@ -77,7 +77,12 @@ object Render {
     var counter = 0
     while (counter < (length - 1)) {
       val (currentEdge, nextEdge) = breaks(counter) -> breaks(counter + 1)
-      val points = currentEdge to nextEdge by (nextEdge - currentEdge) / lengthBetween
+      val step = (nextEdge - currentEdge) / lengthBetween
+      val points: List[Double] = if (step == 0) {
+        List.empty[Double]
+      } else {
+        (currentEdge to nextEdge by step).toList
+      }
 
       val append = if (counter == 0) points else points.tail
       listBuffer ++= append


### PR DESCRIPTION
## Overview

Interpolation can sometimes attempt to construct breaks from duplicate values. If we don't check for this, a step size of 0 can be used. This leads to an exception which we can avoid if we simply construct an empty list when the desired step size is 0 (which makes sense because there's nothing to interpolate)

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

Run `ogc-example` project's `RenderSpec`

Closes #111
