### PR TITLE
Fix/provide appropriate warnings for colormap configuration

### DIFF
--- a/ogc-example/docs/conf.md
+++ b/ogc-example/docs/conf.md
@@ -210,6 +210,14 @@ color-maps = {
       32: 0x969798FF,
 ```
 
+> WARNING: The particular syntax used for GT Server configuration is HOCON,
+> which has some issues dealing with numeric values (decimal/floating
+> point numbers in particular) in the keys of maps. We advise always
+> quoting the keys of ColorMap definitions (e.g. `"0.1": 0xFF00FF`) or
+> at least always padding floating point keys to the tenth place (`0.0`
+> will work, whereas `0` might cause problems) to avoid configuration
+> parsing issues.
+
 #### Providing a style legend
 
 In addition to defining rendering, styles optionally provide legends to help

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -391,7 +391,7 @@ color-maps = {
     -0.3: 0x9CB0CEFF,
     -0.2: 0xBDCAD5FF,
     -0.1: 0xDEE4DDFF,
-    "0": 0xFFFFE5FF,
+    "0.0": 0xFFFFE5FF,
     "0.1": 0xDAE4CAFF,
     "0.2": 0xB6C9AFFF,
     "0.3": 0x91AF94FF,

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -84,12 +84,11 @@ package object conf {
         v.valueType match {
           case ConfigValueType.OBJECT =>
             val confmap = v.asInstanceOf[ConfigObject].asScala
-            val ans = confmap.map { case (ck, cv) =>
+            confmap.map { case (ck, cv) =>
               val key = k + "." + ck
               val value = cv.unwrapped.asInstanceOf[String]
               key -> value
             }
-            ans
           case ConfigValueType.STRING => 
             List(k -> v.unwrapped.asInstanceOf[String])
           case _ =>

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -73,20 +73,27 @@ package object conf {
    * HOCON doesn't naturally handle unquoted strings which contain decimals ('.') very well.
    *  As a result, some special configuration handling is required here to allow unquoted
    *  strings specifically when we know we're trying to decode a ColorMap.
+   * 
+   * @note It is currently difficult to handle double-keyed maps. A workaround
+   * has been provided, but it only works with doubles that explicitly decimal
+   * pad to tenths (0.0 is OK, 0 is to be avoided)
    */
   implicit def colormapReader: ConfigReader[ColorMap] =
     ConfigReader[Map[String, ConfigValue]].map { cmap =>
-      val numericMap = cmap.map({ case (k, v) =>
+      val numericMap = cmap.flatMap({ case (k, v) =>
         v.valueType match {
           case ConfigValueType.OBJECT =>
             val confmap = v.asInstanceOf[ConfigObject].asScala
-            val fixedKey: String = k + "." + confmap.keys.head
-            val fixedValue: String = confmap.values.head.unwrapped.asInstanceOf[String]
-            fixedKey -> fixedValue
+            val ans = confmap.map { case (ck, cv) =>
+              val key = k + "." + ck
+              val value = cv.unwrapped.asInstanceOf[String]
+              key -> value
+            }
+            ans
           case ConfigValueType.STRING => 
-            k -> v.unwrapped.asInstanceOf[String]
+            List(k -> v.unwrapped.asInstanceOf[String])
           case _ =>
-            k -> v.toString
+            List(k -> v.toString)
         }
       }).map({ case (k, v) =>
         val key = k.toDouble

--- a/ogc-example/src/test/scala/geotrellis/server/ogc/conf/ColorMapConfigurationSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/ogc/conf/ColorMapConfigurationSpec.scala
@@ -1,0 +1,27 @@
+package geotrellis.server.ogc
+
+import geotrellis.server.ogc.conf._
+import geotrellis.raster.render.ColorMap
+
+import pureconfig.ConfigSource
+
+import org.scalatest.FunSpec
+import org.scalatest._
+import org.scalatest.Matchers._
+
+class ColorMapConfigurationSpec extends FunSpec {
+
+  describe("ColorMap Configuration") {
+    it("should produce the same colormap regardless of key type") {
+      val quoted =
+        """{"-1.0": 0x1947B0FF,"-0.7": 0x3961B7FF,"-0.5": 0x5A7BBFFF,"-0.4": 0x7B95C6FF,"-0.3": 0x9CB0CEFF,"-0.2": 0xBDCAD5FF,"-0.1": 0xDEE4DDFF,"0": 0xFFFFE5FF,"0.1": 0xDAE4CAFF,"0.2": 0xB6C9AFFF,"0.3": 0x91AF94FF,"0.4": 0x6D9479FF,"0.5": 0x487A5EFF,"0.7": 0x245F43FF,"1.0": 0x004529FF}"""
+      val unquoted =
+        """{-1.0: 0x1947B0FF,-0.7: 0x3961B7FF,-0.5: 0x5A7BBFFF,-0.4: 0x7B95C6FF,-0.3: 0x9CB0CEFF,-0.2: 0xBDCAD5FF,-0.1: 0xDEE4DDFF, 0.0: 0xFFFFE5FF,0.1: 0xDAE4CAFF,0.2: 0xB6C9AFFF,0.3: 0x91AF94FF,0.4: 0x6D9479FF,0.5: 0x487A5EFF,0.7: 0x245F43FF,1.0: 0x004529FF}"""
+
+      val quotedSource = ConfigSource.string(quoted)
+      val unquotedSource = ConfigSource.string(unquoted)
+
+      quotedSource.load[ColorMap].right.get.colors shouldBe (unquotedSource.load[ColorMap].right.get.colors)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   val kamonSysMetrics = "io.kamon" %% "kamon-system-metrics" % "1.0.0"
   val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0"
   val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0"
-  val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.10.2"
+  val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.12.2"
   val refined = "eu.timepit" %% "refined" % refinedVer
   val scaffeine = "com.github.blemale" %% "scaffeine" % "2.6.0"
   val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.1.0"


### PR DESCRIPTION
## Overview

A prior fix for HOCON's not properly handling `Double` keyed maps could sometimes run into trouble if key values were not padded to the tenths place (0 must be 0.0). Additionally, values could be thrown out. Values are no longer thrown out and the need for padding or else quoting has been called out in documentation