### PR TITLE
Add ability to configure subset of OGC services

### DIFF
--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,6 +107,12 @@ object Main extends CommandApp(
               .collect { case ssc @ SimpleSourceConf(_, _, _, _) => ssc.models }
               .toList
               .flatten
+            _ <- Stream.eval(IO {
+              if (conf.wms.isDefined)
+                logger.info(ansi"%green{WMS configuration detected}, starting Web Map Service")
+              else
+                logger.info(ansi"%red{WMS configuration detected}")
+            })
             wmsModel = conf.wms.map { svc =>
               WmsModel(
                 svc.serviceMetadata,
@@ -114,6 +120,12 @@ object Main extends CommandApp(
                 svc.layerSources(simpleSources)
               )
             }
+            _ <- Stream.eval(IO {
+              if (conf.wmts.isDefined)
+                logger.info(ansi"%green{WMTS configuration detected}, starting Web Map Tiling Service")
+              else
+                logger.info(ansi"%red{No WMTS configuration detected}")
+            })
             wmtsModel = conf.wmts.map { svc =>
               WmtsModel(
                 svc.serviceMetadata,
@@ -121,6 +133,12 @@ object Main extends CommandApp(
                 svc.layerSources(simpleSources)
               )
             }
+            _ <- Stream.eval(IO {
+              if (conf.wcs.isDefined)
+                logger.info(ansi"%green{WCS configuration detected}, starting Web Coverage Service")
+              else
+                logger.info(ansi"%red{No WCS configuration detected}")
+            })
             wcsModel = conf.wcs.map { svc =>
               WcsModel(
                 svc.serviceMetadata,

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,20 +107,26 @@ object Main extends CommandApp(
               .collect { case ssc @ SimpleSourceConf(_, _, _, _) => ssc.models }
               .toList
               .flatten
-            wmsModel = WmsModel(
-              conf.wms.serviceMetadata,
-              conf.wms.parentLayerMeta,
-              conf.wms.layerSources(simpleSources)
-            )
-            wmtsModel = WmtsModel(
-              conf.wmts.serviceMetadata,
-              conf.wmts.tileMatrixSets,
-              conf.wmts.layerSources(simpleSources)
-            )
-            wcsModel = WcsModel(
-              conf.wcs.serviceMetadata,
-              conf.wcs.layerSources(simpleSources)
-            )
+            wmsModel = conf.wms.map { svc =>
+              WmsModel(
+                svc.serviceMetadata,
+                svc.parentLayerMeta,
+                svc.layerSources(simpleSources)
+              )
+            }
+            wmtsModel = conf.wmts.map { svc =>
+              WmtsModel(
+                svc.serviceMetadata,
+                svc.tileMatrixSets,
+                svc.layerSources(simpleSources)
+              )
+            }
+            wcsModel = conf.wcs.map { svc =>
+              WcsModel(
+                svc.serviceMetadata,
+                svc.layerSources(simpleSources)
+              )
+            }
             ogcService = new OgcService(wmsModel, wcsModel, wmtsModel, new URL(publicUrl))
             exitCode   <- BlazeServerBuilder[IO]
               .withIdleTimeout(Duration.Inf) // for test purposes only

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,12 +107,11 @@ object Main extends CommandApp(
               .collect { case ssc @ SimpleSourceConf(_, _, _, _) => ssc.models }
               .toList
               .flatten
-            _ <- Stream.eval(IO {
-              if (conf.wms.isDefined)
-                logger.info(ansi"%green{WMS configuration detected}, starting Web Map Service")
-              else
-                logger.info(ansi"%red{WMS configuration detected}")
-            })
+            _ <- Stream.eval(IO { conf.wms.fold(
+              logger.info(ansi"%red{WMS configuration detected}")
+            )({ _ =>
+              logger.info(ansi"%green{WMS configuration detected}, starting Web Map Service")
+            })})
             wmsModel = conf.wms.map { svc =>
               WmsModel(
                 svc.serviceMetadata,
@@ -120,12 +119,11 @@ object Main extends CommandApp(
                 svc.layerSources(simpleSources)
               )
             }
-            _ <- Stream.eval(IO {
-              if (conf.wmts.isDefined)
-                logger.info(ansi"%green{WMTS configuration detected}, starting Web Map Tiling Service")
-              else
-                logger.info(ansi"%red{No WMTS configuration detected}")
-            })
+            _ <- Stream.eval(IO { conf.wmts.fold(
+              logger.info(ansi"%red{No WMTS configuration detected}")
+            )({ _ =>
+              logger.info(ansi"%green{WMTS configuration detected}, starting Web Map Tiling Service")
+            })})
             wmtsModel = conf.wmts.map { svc =>
               WmtsModel(
                 svc.serviceMetadata,
@@ -133,12 +131,11 @@ object Main extends CommandApp(
                 svc.layerSources(simpleSources)
               )
             }
-            _ <- Stream.eval(IO {
-              if (conf.wcs.isDefined)
-                logger.info(ansi"%green{WCS configuration detected}, starting Web Coverage Service")
-              else
-                logger.info(ansi"%red{No WCS configuration detected}")
-            })
+            _ <- Stream.eval(IO { conf.wcs.fold(
+              logger.info(ansi"%red{No WCS configuration detected}")
+            )({ _ =>
+              logger.info(ansi"%green{WCS configuration detected}, starting Web Coverage Service")
+            })})
             wcsModel = conf.wcs.map { svc =>
               WcsModel(
                 svc.serviceMetadata,

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
@@ -36,9 +36,9 @@ import scalaxb.DataRecord
  */
 case class Conf(
   layers: Map[String, OgcSourceConf],
-  wms: WmsConf,
-  wmts: WmtsConf,
-  wcs: WcsConf
+  wms: Option[WmsConf],
+  wmts: Option[WmtsConf],
+  wcs: Option[WcsConf]
 )
 
 object Conf {


### PR DESCRIPTION
## Overview

It shouldn't be necessary to run a WMS service in order to run a WCS service. This PR makes all top level service configurations optional; empty configuration blocks are tolerated

All supplied:
![image](https://user-images.githubusercontent.com/1977405/75197957-77023680-572d-11ea-8d15-16e174206c79.png)

Only WMTS supplied:
![image](https://user-images.githubusercontent.com/1977405/75198087-c5173a00-572d-11ea-846d-6e6ab8f9f44b.png)


Closes #151 
