### PR TITLE
Add interpolated color map styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add support for an interpolated version of the color map [#161](https://github.com/geotrellis/geotrellis-server/issues/161)
 - Generate WCS 1.1.1 protocol using XSD data model [#188](https://github.com/geotrellis/geotrellis-server/issues/188)
 - WCS 1.1.1 GetCoverage Support [#192](https://github.com/geotrellis/geotrellis-server/issues/192)
 - RasterSource Catalog [#162](https://github.com/geotrellis/geotrellis-server/issues/162)

--- a/ogc-example/docs/conf.md
+++ b/ogc-example/docs/conf.md
@@ -137,8 +137,8 @@ currently supported:
 
 Note above that each layer is configured with 0 or more style
 objects. Each provided style object defines an alternative coloring
-strategy. At the highest level, this server has two flavors of styling
-object: `ColorRamp` and `ColorMap` based.
+strategy. At the highest level, this server has three flavors of styling
+object: `ColorRamp`, `ColorMap` and `InterpolatedColorMap` based.
 
 Color ramps are just a list of colors and it is up to the server to
 produce the statistics necessary to make decisions about where (in
@@ -170,22 +170,6 @@ color-ramps = {
     ]
 ```
 
-A word of caution about color ramps: statistically derived rendering
-strategies can mislead if the entire layer being colored is markedly
-different from a well known distribution. If, for instance, we have NDVI
-values from a recent wildfire and our layer contains little information
-outside of the damaged area, statistically derived styling will see a
-distribution skewing towards -1 (or 0, depending on how the NDVI is
-calculated) and is therefore likely to use too many color breaks in the
-low end of the NDVI range.
-
-In a cases like the one just described, you're better off using a color map
-that is defined specifically for the range of values capable of being
-represented (e.g. for NDVI -1 is red, 0 is yellow, and 1 is green
-regardless of the distribution of NDVI values I happen to be looking
-at). If only the minimum and maximum values are known, they may
-optionally be specified in color ramp configuration (as above).
-
 A color map style definition from `application.conf` (note the HOCON
 reference):
 ```
@@ -210,13 +194,35 @@ color-maps = {
       32: 0x969798FF,
 ```
 
+An interpolated color map style definition from `application.conf` (note the HOCON reference):
+```
+{
+    name = "interpolated-income"
+    title = "Income rendered with interpolated values"
+    type = "interpolatedcolormapconf"
+    color-map = ${interpolated-color-maps.income}
+}
+```
+
+The interpolated color map definition referred to above:
+```
+    "income": {
+        "poles": {
+            "0.0": 0xFF0000FF,
+            "75000.0": 0x777700FF
+            "200000.0": 0x00FF00FF,
+        }
+        "clip-definition": "clip-both"
+    }
+```
+
 > WARNING: The particular syntax used for GT Server configuration is HOCON,
 > which has some issues dealing with numeric values (decimal/floating
 > point numbers in particular) in the keys of maps. We advise always
-> quoting the keys of ColorMap definitions (e.g. `"0.1": 0xFF00FF`) or
-> at least always padding floating point keys to the tenth place (`0.0`
-> will work, whereas `0` might cause problems) to avoid configuration
-> parsing issues.
+> quoting the keys of `ColorMap` and `InterpolatedColorMap` definitions
+> (e.g. `"0.1": 0xFF00FF`) or at least always padding floating point keys
+> to the tenth place (`0.0` will work, whereas `0` might cause problems) to
+> avoid configuration parsing issues.
 
 #### Providing a style legend
 

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -229,6 +229,18 @@ layers = {
                 title = "NDVI colors (for demonstration only)"
                 type = "colormapconf"
                 color-map = ${color-maps.ndvi}
+            },
+            {
+                name = "interpolated-nlcd"
+                title = "Interpolated NLCD colors (for demonstration only)"
+                type = "interpolatedcolormapconf"
+                color-map = ${interpolated-color-maps.almost-nlcd}
+            },
+            {
+                name = "interpolated-ndvi"
+                title = "Interpolated NDVI colors (for demonstration only)"
+                type = "interpolatedcolormapconf"
+                color-map = ${interpolated-color-maps.ndvi}
             }
         ]
     }
@@ -244,7 +256,14 @@ layers = {
             band-count = 1
         }
 
-        styles = []
+        styles = [
+            {
+                name = "interpolated-income"
+                title = "Interpolated colors from red (low) to green (high) income"
+                type = "interpolatedcolormapconf"
+                color-map = ${interpolated-color-maps.income}
+            }
+        ]
     }
     us-ned = {
         type = "simplesourceconf"
@@ -401,4 +420,32 @@ color-maps = {
     "0.7": 0x245F43FF,
     "1.0": 0x004529FF
   }
+}
+
+interpolated-color-maps = {
+    "ndvi": {
+        "poles": {
+            "-1.0": 0x770000FF,
+            "0.0": 0xFF0000FF,
+            "0.5": 0xFFFF00FF,
+            "1.0": 0x006600FF
+        }
+        "clip-definition": "clip-none"
+    }
+    "almost-nlcd": {
+        "poles": {
+            "0.0": 0x0000FFFF,
+            "50.0": 0x00FF00FF
+            "100.0": 0xFF0000FF,
+        }
+        "clip-definition": "clip-both"
+    }
+    "income": {
+        "poles": {
+            "0.0": 0xFF0000FF,
+            "75000.0": 0x777700FF
+            "200000.0": 0x00FF00FF,
+        }
+        "clip-definition": "clip-both"
+    }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
@@ -16,6 +16,7 @@
 
 package geotrellis.server.ogc.conf
 
+import geotrellis.server.ogc.style.ClipDefinition
 import geotrellis.server.ogc.ows
 import geotrellis.server.ogc.wms.WmsParentLayerMeta
 
@@ -42,6 +43,7 @@ case class Conf(
 )
 
 object Conf {
+  implicitly[ConfigReader[ClipDefinition]]
   lazy val conf: Conf = ConfigSource.default.loadOrThrow[Conf]
   implicit def ConfObjectToClass(obj: Conf.type): Conf = conf
 

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/Conf.scala
@@ -43,7 +43,6 @@ case class Conf(
 )
 
 object Conf {
-  implicitly[ConfigReader[ClipDefinition]]
   lazy val conf: Conf = ConfigSource.default.loadOrThrow[Conf]
   implicit def ConfObjectToClass(obj: Conf.type): Conf = conf
 

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/StyleConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/StyleConf.scala
@@ -17,6 +17,7 @@
 package geotrellis.server.ogc.conf
 
 import geotrellis.server.ogc._
+import geotrellis.server.ogc.style._
 
 import geotrellis.raster.render.{ColorMap, ColorRamp}
 
@@ -37,7 +38,8 @@ final case class ColorRampConf(
   maxRender: Option[Double],
   legends: List[LegendModel] = Nil
 ) extends StyleConf {
-  def toStyle: OgcStyle = ColorRampStyle(name, title, colors, stops, minRender, maxRender, legends)
+  def toStyle: OgcStyle =
+    ColorRampStyle(name, title, colors, stops, minRender, maxRender, legends)
 }
 
 /** Styling in which both a color scheme and the data-to-color mapping is known */
@@ -47,5 +49,16 @@ final case class ColorMapConf(
   colorMap: ColorMap,
   legends: List[LegendModel] = Nil
 ) extends StyleConf {
-  def toStyle: OgcStyle = ColorMapStyle(name, title, colorMap, legends)
+  def toStyle: OgcStyle =
+    ColorMapStyle(name, title, colorMap, legends)
+}
+
+final case class InterpolatedColorMapConf(
+  name: String,
+  title: String,
+  colorMap: InterpolatedColorMap,
+  legends: List[LegendModel] = Nil
+) extends StyleConf {
+  def toStyle: OgcStyle =
+    InterpolatedColorMapStyle(name, title, colorMap, legends)
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -66,7 +66,7 @@ package object conf {
       }
     }
 
-  implicit def colorRampReader: ConfigReader[ColorRamp] =
+  implicit val colorRampReader: ConfigReader[ColorRamp] =
     ConfigReader[List[String]].map { colors =>
       ColorRamp(colors.map(java.lang.Long.decode(_).toInt))
     }
@@ -80,7 +80,7 @@ package object conf {
    * has been provided, but it only works with doubles that explicitly decimal
    * pad to tenths (0.0 is OK, 0 is to be avoided)
    */
-  implicit def mapDoubleIntReader: ConfigReader[Map[Double, Int]] =
+  implicit val mapDoubleIntReader: ConfigReader[Map[Double, Int]] =
     ConfigReader[Map[String, ConfigValue]].map { cmap =>
       val numericMap = cmap.flatMap({ case (k, v) =>
         v.valueType match {
@@ -104,7 +104,7 @@ package object conf {
       numericMap
     }
 
-  implicit def colormapReader: ConfigReader[ColorMap] =
+  implicit val colormapReader: ConfigReader[ColorMap] =
     ConfigReader[Map[Double, Int]].map { map =>
       ColorMap(map)
     }
@@ -119,12 +119,12 @@ package object conf {
       }
     }
 
-  implicit def keywordConfigReader: ConfigReader[opengis.wms.Keyword] =
+  implicit val keywordConfigReader: ConfigReader[opengis.wms.Keyword] =
     ConfigReader[String].map { str =>
       opengis.wms.Keyword(str)
     }
 
-  implicit def nameConfigReader: ConfigReader[opengis.wms.Name] =
+  implicit val nameConfigReader: ConfigReader[opengis.wms.Name] =
     ConfigReader[String].map { str =>
       opengis.wms.Name.fromString(str, wmsScope)
     }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -18,14 +18,16 @@ package geotrellis.server.ogc.wmts
 
 import geotrellis.server._
 import geotrellis.server.ogc._
+import geotrellis.server.ogc.style._
 import geotrellis.server.ogc.params.ParamError
 import geotrellis.server.ogc.wmts.WmtsParams.{GetCapabilities, GetTile}
-import com.azavea.maml.eval._
 
 import geotrellis.layer._
 import geotrellis.proj4._
 import geotrellis.raster.render.{ColorMap, ColorRamp, Png}
 import geotrellis.raster._
+import com.azavea.maml.eval._
+
 import scalaxb.CanWriteXML
 import org.http4s.scalaxml._
 import org.http4s._, org.http4s.dsl.io._, org.http4s.implicits._

--- a/ogc-example/src/test/scala/geotrellis/server/ogc/conf/ColorMapConfigurationSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/ogc/conf/ColorMapConfigurationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc
 
 import geotrellis.server.ogc.conf._

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
@@ -17,6 +17,8 @@
 package geotrellis.server.ogc
 
 import geotrellis.server._
+import geotrellis.server.ogc.style._
+
 import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.raster.io.geotiff._

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
@@ -18,6 +18,8 @@ package geotrellis.server.ogc
 
 import geotrellis.server.extent.SampleUtils
 import geotrellis.server.ogc.wms._
+import geotrellis.server.ogc.style._
+
 import geotrellis.raster._
 import geotrellis.vector.{Extent, ProjectedExtent}
 import geotrellis.proj4.CRS

--- a/ogc/src/main/scala/geotrellis/server/ogc/OutputFormat.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OutputFormat.scala
@@ -16,6 +16,8 @@
 
 package geotrellis.server.ogc
 
+import geotrellis.server.ogc.style._
+
 import scala.util.Try
 import geotrellis.raster.render.png._
 import geotrellis.raster._
@@ -74,6 +76,26 @@ object OutputFormat {
     }
 
     def render(tile: Tile, cm: ColorMap) = {
+      val encoder = encoding match {
+        case None =>
+          new PngEncoder(Settings(RgbaPngEncoding, PaethFilter))
+
+        case Some(GreyPngEncoding(None)) =>
+          val nd = noDataValue(tile.cellType)
+          new PngEncoder(Settings(GreyPngEncoding(nd), PaethFilter))
+
+        case Some(RgbPngEncoding(None)) =>
+          val nd = noDataValue(tile.cellType)
+          new PngEncoder(Settings(RgbPngEncoding(nd), PaethFilter))
+
+        case Some(encoding) =>
+          new PngEncoder(Settings(encoding, PaethFilter))
+      }
+
+      encoder.writeByteArray(cm.render(tile))
+    }
+
+    def render(tile: Tile, cm: InterpolatedColorMap): Array[Byte] = {
       val encoder = encoding match {
         case None =>
           new PngEncoder(Settings(RgbaPngEncoding, PaethFilter))

--- a/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/Render.scala
@@ -16,6 +16,8 @@
 
 package geotrellis.server.ogc
 
+import geotrellis.server.ogc.style._
+
 import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._

--- a/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
@@ -17,6 +17,8 @@
 package geotrellis.server.ogc
 
 import geotrellis.server._
+import geotrellis.server.ogc.style.OgcStyle
+
 import geotrellis.layer._
 import geotrellis.raster._
 import geotrellis.raster.reproject.ReprojectRasterExtent

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/ClipDefinition.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/ClipDefinition.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.style
+
+import org.log4s._
+import cats.syntax.option._
+
+
+abstract class ClipDefinition(repr: String) extends Product with Serializable
+case object ClipNone extends ClipDefinition("clip-none")
+case object ClipLeft extends ClipDefinition("clip-left")
+case object ClipRight extends ClipDefinition("clip-right")
+case object ClipBoth extends ClipDefinition("clip-both")
+
+object ClipDefinition {
+  private val logger = getLogger
+
+  def fromString(str: String): Option[ClipDefinition] =
+    str match {
+      case "clip-none" => ClipNone.some
+      case "clip-left" => ClipLeft.some
+      case "clip-right" => ClipRight.some
+      case "clip-both" => ClipBoth.some
+      case _ =>
+        logger.warn(s"Unable to deserialize string as ClipDefinition $str")
+        None
+    }
+
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/ColorMapStyle.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/ColorMapStyle.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.style
+
+import geotrellis.server.ogc._
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.render.{ColorMap, ColorRamp}
+import geotrellis.raster.render.jpg.JpgEncoder
+import geotrellis.util.np.linspace
+
+
+case class ColorMapStyle(
+  name: String,
+  title: String,
+  colorMap: ColorMap,
+  legends: List[LegendModel] = Nil
+) extends OgcStyle {
+  def renderImage(
+    mbtile: MultibandTile,
+    format: OutputFormat,
+    hists: List[Histogram[Double]]
+  ): Array[Byte] = {
+    format match {
+      case format: OutputFormat.Png =>
+        format.render(mbtile.band(bandIndex = 0), colorMap)
+
+      case OutputFormat.Jpg =>
+        mbtile.band(bandIndex = 0).renderJpg(colorMap).bytes
+
+      case OutputFormat.GeoTiff => ??? // Implementation necessary
+    }
+  }
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/ColorRampStyle.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/ColorRampStyle.scala
@@ -14,42 +14,16 @@
  * limitations under the License.
  */
 
-package geotrellis.server.ogc
+package geotrellis.server.ogc.style
+
+import geotrellis.server.ogc._
 
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.render.{ColorMap, ColorRamp}
+import geotrellis.raster.render.jpg.JpgEncoder
 import geotrellis.util.np.linspace
 
-trait OgcStyle {
-  def name: String
-  def title: String
-  def legends: List[LegendModel]
-  def renderImage(mbtile: MultibandTile, format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte]
-}
-
-case class ColorMapStyle(
-  name: String,
-  title: String,
-  colorMap: ColorMap,
-  legends: List[LegendModel] = Nil
-) extends OgcStyle {
-  def renderImage(
-    mbtile: MultibandTile,
-    format: OutputFormat,
-    hists: List[Histogram[Double]]
-  ): Array[Byte] = {
-    format match {
-      case format: OutputFormat.Png =>
-        format.render(mbtile.band(bandIndex = 0), colorMap)
-
-      case OutputFormat.Jpg =>
-        mbtile.band(bandIndex = 0).renderJpg(colorMap).bytes
-
-      case OutputFormat.GeoTiff => ??? // Implementation necessary
-    }
-  }
-}
 
 case class ColorRampStyle(
   name: String,
@@ -103,19 +77,3 @@ case class ColorRampStyle(
     }
   }
 }
-
-case class LegendModel(
-  format: String,
-  width: Int,
-  height: Int,
-  onlineResource: OnlineResourceModel
-)
-
-case class OnlineResourceModel(
-  `type`: String,
-  href: String,
-  role: Option[String] = None,
-  title: Option[String] = None,
-  show: Option[String] = None,
-  actuate: Option[String] = None
-)

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/InterpolatedColorMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/InterpolatedColorMap.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.style
+
+import geotrellis.raster.render._
+import geotrellis.raster.{RGBA => _, _}
+
+import scala.math._
+import java.util.Arrays.binarySearch
+
+
+case class InterpolatedColorMap(
+  poles: Map[Double, Int],
+  clipDefinition: ClipDefinition
+) {
+  import InterpolatedColorMap._
+
+  def interpolate: Double => Int =
+    { dbl: Double => interpolation(poles, clipDefinition)(dbl) }
+
+  def render(tile: Tile): Tile =
+    if (tile.cellType.isFloatingPoint) {
+      tile.mapDouble({ cellValue: Double =>
+        if (isData(cellValue)) interpolate(cellValue).int
+        else 0
+      })
+    } else {
+      tile.map({ cellValue: Int =>
+        if (isData(cellValue)) interpolate(cellValue).int
+        else 0
+      })
+    }
+}
+
+object InterpolatedColorMap {
+  /** RGB color interpolation logic */
+  private def RgbLerp(color1: Int, color2: Int, proportion: Double): Int = {
+    val r = (color1.red + (color2.red - color1.red) * proportion).toInt
+    val g = (color1.green + (color2.green - color1.green) * proportion).toInt
+    val b = (color1.blue + (color2.blue - color1.blue) * proportion).toInt
+    val a: Double = (color1.alpha + (color2.alpha - color1.alpha) * proportion).toDouble / 2.55
+    RGBA(r, g, b, a)
+  }
+
+  /** For production of colors along a continuum */
+  def interpolation(poles: Map[Double, Int], clipDefinition: ClipDefinition): Double => Int =
+    { dbl: Double =>
+      val decomposed = poles.toArray.sortBy(_._1).unzip
+      val breaks: Array[Double] = decomposed._1
+      val colors: Array[Int] = decomposed._2.map(_.int)
+
+      val insertionPoint: Int = binarySearch(breaks, dbl)
+      if (insertionPoint == -1) {
+        // MIN VALUE
+        clipDefinition match {
+          case ClipNone | ClipRight => colors(0)
+          case ClipLeft | ClipBoth => 0x00000000
+        }
+      } else if (abs(insertionPoint) - 1 == breaks.size) {
+        // MAX VALUE
+        clipDefinition match {
+          case ClipNone | ClipLeft => colors.last
+          case ClipRight | ClipBoth => 0x00000000
+        }
+      } else if (insertionPoint < 0) {
+        // MUST INTERPOLATE
+        val lowerIdx = abs(insertionPoint) - 2
+        val higherIdx = abs(insertionPoint) - 1
+        val lower = breaks(lowerIdx)
+        val higher = breaks(higherIdx)
+        val proportion = (dbl - lower) / (higher - lower)
+
+        RgbLerp(colors(lowerIdx), colors(higherIdx), proportion)
+      } else {
+        // Direct hit
+        colors(insertionPoint)
+      }
+    }
+  }

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/InterpolatedColorMapStyle.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/InterpolatedColorMapStyle.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.style
+
+import geotrellis.server.ogc._
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.render.{ColorMap, ColorRamp}
+import geotrellis.raster.render.jpg.JpgEncoder
+import geotrellis.util.np.linspace
+
+
+case class InterpolatedColorMapStyle(
+  name: String,
+  title: String,
+  colorMap: InterpolatedColorMap,
+  legends: List[LegendModel] = Nil
+) extends OgcStyle {
+  def renderImage(
+    mbtile: MultibandTile,
+    format: OutputFormat,
+    hists: List[Histogram[Double]]
+  ): Array[Byte] = {
+    format match {
+      case format: OutputFormat.Png =>
+        format.render(mbtile.band(bandIndex = 0), colorMap)
+
+      case OutputFormat.Jpg =>
+        colorMap.render(mbtile.band(bandIndex = 0)).renderJpg().bytes
+
+      case OutputFormat.GeoTiff => ??? // Implementation necessary
+    }
+  }
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/LegendModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/LegendModel.scala
@@ -1,0 +1,8 @@
+package geotrellis.server.ogc.style
+
+case class LegendModel(
+  format: String,
+  width: Int,
+  height: Int,
+  onlineResource: OnlineResourceModel
+)

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/OgcStyle.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/OgcStyle.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.style
+
+import geotrellis.server.ogc.OutputFormat
+
+import geotrellis.raster._
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.render.{ColorMap, ColorRamp}
+import geotrellis.raster.render.jpg.JpgEncoder
+import geotrellis.util.np.linspace
+
+trait OgcStyle {
+  def name: String
+  def title: String
+  def legends: List[LegendModel]
+  def renderImage(mbtile: MultibandTile, format: OutputFormat, hists: List[Histogram[Double]]): Array[Byte]
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/OnlineResourceModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/OnlineResourceModel.scala
@@ -1,0 +1,11 @@
+package geotrellis.server.ogc.style
+
+
+case class OnlineResourceModel(
+  `type`: String,
+  href: String,
+  role: Option[String] = None,
+  title: Option[String] = None,
+  show: Option[String] = None,
+  actuate: Option[String] = None
+)

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -17,6 +17,7 @@
 package geotrellis.server.ogc.wms
 
 import geotrellis.server.ogc._
+import geotrellis.server.ogc.style._
 
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster.CellSize

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -17,6 +17,7 @@
 package geotrellis.server.ogc.wms
 
 import geotrellis.server.ogc._
+import geotrellis.server.ogc.style._
 import geotrellis.server.ogc.wms.WmsParams.GetMap
 
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
@@ -16,12 +16,13 @@
 
 package geotrellis.server.ogc
 
+import geotrellis.server.ogc.style._
+
 import opengis._
 import opengis.wms._
 import scalaxb._
 
 import java.net.URI
-
 import scala.xml.NamespaceBinding
 
 package object wms {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -17,9 +17,11 @@
 package geotrellis.server.ogc.wmts
 
 import geotrellis.server.ogc._
+import geotrellis.server.ogc.style._
+import geotrellis.server.ogc.wmts.WmtsParams.GetTile
+
 import geotrellis.layer._
 import geotrellis.proj4._
-import geotrellis.server.ogc.wmts.WmtsParams.GetTile
 
 /** This class holds all the information necessary to construct a response to a WMTS request */
 case class WmtsModel(

--- a/ogc/src/test/scala/geotrellis/server/ogc/InterpolatedColorMapSpec.scala
+++ b/ogc/src/test/scala/geotrellis/server/ogc/InterpolatedColorMapSpec.scala
@@ -1,0 +1,72 @@
+package geotrellis.server.ogc
+
+import geotrellis.server.ogc.style._
+
+import geotrellis.raster.render.{ColorRamp, RGBA}
+import geotrellis.raster.histogram.DoubleHistogram
+
+import org.scalatest.FunSpec
+import org.scalatest._
+import org.scalatest.Matchers._
+
+
+class InterpolatedColorMapSpec extends FunSpec {
+  describe("InterpolatedColorMap") {
+    val minColor = RGBA(255, 0, 0, 100)
+    val medColor = RGBA(0, 255, 0, 100)
+    val maxColor = RGBA(0, 0, 255, 100)
+    val clippedColor = RGBA(0, 0, 0, 0)
+    val poles =
+      Map[Double, Int](
+        -100.0 -> minColor,
+        0.0 -> medColor,
+        100.0 -> maxColor
+      )
+
+    it("should interpolate based based on the two nearest poles") {
+      val clipDefinition = ClipNone
+      val interpolate =
+        InterpolatedColorMap.interpolation(poles, clipDefinition)
+      val interpolated = interpolate(50.0)
+      val expected = RGBA(0, 127, 127, 100)
+
+      interpolated shouldBe (expected)
+      interpolated.red shouldBe (expected.red)
+      interpolated.blue shouldBe (expected.blue)
+      interpolated.green shouldBe (expected.green)
+    }
+
+    it("should respect clip definition: none") {
+      val clipDefinition = ClipNone
+      val interpolate =
+        InterpolatedColorMap.interpolation(poles, clipDefinition)
+      val i = interpolate(Double.MinValue)
+      interpolate(Double.MinValue) shouldBe (minColor)
+      interpolate(Double.MaxValue) shouldBe (maxColor)
+    }
+
+    it("should respect clip definition: left") {
+      val clipDefinition = ClipLeft
+      val interpolate =
+        InterpolatedColorMap.interpolation(poles, clipDefinition)
+      interpolate(Double.MinValue) shouldBe (clippedColor)
+      interpolate(Double.MaxValue) shouldBe (maxColor)
+    }
+
+    it("should respect clip definition: right") {
+      val clipDefinition = ClipRight
+      val interpolate =
+        InterpolatedColorMap.interpolation(poles, clipDefinition)
+      interpolate(Double.MinValue) shouldBe (minColor)
+      interpolate(Double.MaxValue) shouldBe (clippedColor)
+    }
+
+    it("should respect clip definition: both") {
+      val clipDefinition = ClipBoth
+      val interpolate =
+        InterpolatedColorMap.interpolation(poles, clipDefinition)
+      interpolate(Double.MinValue) shouldBe (clippedColor)
+      interpolate(Double.MaxValue) shouldBe (clippedColor)
+    }
+  }
+}

--- a/ogc/src/test/scala/geotrellis/server/ogc/OgcStyleSpec.scala
+++ b/ogc/src/test/scala/geotrellis/server/ogc/OgcStyleSpec.scala
@@ -1,5 +1,7 @@
 package geotrellis.server.ogc
 
+import geotrellis.server.ogc.style._
+
 import geotrellis.raster.render.ColorRamp
 import geotrellis.raster.histogram.DoubleHistogram
 


### PR DESCRIPTION
## Overview

GT Server already has a `ColorRamp` and `ColorMap` styling but currently lacks a way to define fine grained interpolation between preset poles and their associated colors. This PR rectifies that situation by introducing the `InterpolatedColorMap` and the mechanisms necessary to define/configure them

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

This style conf:
```javascript
    "income": {
        "poles": {
            "0.0": 0xFF0000FF,
            "75000.0": 0x777700FF
            "200000.0": 0x00FF00FF,
        }
        "clip-definition": "clip-both"
    }
```
applied to a median household income layer produces this layer:
![image](https://user-images.githubusercontent.com/1977405/75486683-fafd2e00-597a-11ea-9dac-394201e6b866.png)



### Notes

The same parsing difficulties that HOCON creates for regular `ColorMap`s continue to be potential issues here


Closes #161
