### PR TITLE
Add timesequence param for WCS GetCoverage requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RasterSource Catalog [#162](https://github.com/geotrellis/geotrellis-server/issues/162)
 - {WCS|WMTS|WMS}Model uses RasterSource catalog [#163](https://github.com/geotrellis/geotrellis-server/issues/163)
 - WCS DescribeCoverage may include time TemporalDomain [#211](https://github.com/geotrellis/geotrellis-server/issues/211)
+- WCS GetCoverage may include time param `TIMESEQUENCE` [#157](https://github.com/geotrellis/geotrellis-server/issues/157)
 
 ### Changed
 - Included split dependencies a la GeoTrellis 3.2 for cats ecosystem libraries [\#184](https://github.com/geotrellis/geotrellis-server/pull/184)

--- a/core/src/main/scala/geotrellis/store/query/RasterSourceRepository.scala
+++ b/core/src/main/scala/geotrellis/store/query/RasterSourceRepository.scala
@@ -49,7 +49,7 @@ object RasterSourceRepository {
     }
     case At(t, fn)           => _.filter(_.metadata.attributes.get(fn).map(ZonedDateTime.parse).fold(false)(_ == t))
     case Between(t1, t2, fn) => _.filter {
-      _.metadata.attributes.get(fn).map(ZonedDateTime.parse).fold(false) { current => t1 >= current && t2 < current }
+      _.metadata.attributes.get(fn).map(ZonedDateTime.parse).fold(false) { current => t1 <= current && current < t2 }
     }
     case Intersects(e) => _.filter(_.projectedExtent.intersects(e))
     case Covers(e)     => _.filter(_.projectedExtent.covers(e))

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcSourceRepository.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcSourceRepository.scala
@@ -36,7 +36,7 @@ object OgcSourceRepository {
     case WithNames(names)    => _.filter(rs => names.contains(rs.name))
     case At(t, _)           => _.filter(_.time.exists(_ == t))
     case Between(t1, t2, _) => _.filter { _.time match {
-        case Some(t) => t1 >= t && t2 < t
+        case Some(t) => t1 <= t && t < t2
         case _ => false
       }
     }

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
@@ -1,0 +1,49 @@
+package geotrellis.server.ogc
+
+import java.time.ZonedDateTime
+
+/**
+  * Represents the TimeInterval and TimePosition types used in TimeSequence requests
+  *
+  * If end is provided, a TimeInterval is assumed. Otherwise, a TimePosition.
+  *
+  * @param start The start time for this TimePosition or TimeInterval
+  * @param end The end time for this TimeInterval. If None, a TimePosition is assumed from the
+  *              start param.
+  * @param interval ISO 8601:2000 provides a syntax for expressing time periods: the designator P,
+  *                 followed by a number of years Y, months M, days D, a time designator T, number
+  *                 of hours H, minutes M, and seconds S. Unneeded elements may be omitted. Here are
+  *                 a few examples:
+  *                 EXAMPLE 1 -  P1Y, 1 year
+  *                 EXAMPLE 2 - P1M10D, 1 month plus 10 days
+  *                 EXAMPLE 3 - PT2H, 2 hours
+  *
+  *                 @note This param is not validated. It is up to the user to ensure that it is
+  *                       encoded directly
+  */
+final case class OgcTimeInterval(start: ZonedDateTime,
+                                 end: Option[ZonedDateTime],
+                                 interval: Option[String]) {
+  override def toString: String = {
+    end match {
+      case Some(e) => s"${start.toInstant.toString}/${e.toInstant.toString}${interval.map("/" + _).getOrElse("")}"
+      case _ => start.toInstant.toString
+    }
+  }
+}
+
+object OgcTimeInterval {
+  def apply(timePeriod: ZonedDateTime): OgcTimeInterval = OgcTimeInterval(timePeriod, None, None)
+
+  def fromString(timeString: String): OgcTimeInterval = {
+    val timeParts = timeString.split("/")
+    timeParts match {
+      case Array(start, end, interval) =>
+        OgcTimeInterval(ZonedDateTime.parse(start), Some(ZonedDateTime.parse(end)), Some(interval))
+      case Array(start, end) =>
+        OgcTimeInterval(ZonedDateTime.parse(start), Some(ZonedDateTime.parse(end)), None)
+      case Array(start) => OgcTimeInterval(ZonedDateTime.parse(start))
+      case _ => throw new UnsupportedOperationException("Unsupported string format for OgcTimeInterval")
+    }
+  }
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -24,14 +24,17 @@ case class WcsModel(
   sources: OgcSourceRepository
 ) {
 
-  def getLayers(p: GetCoverageWcsParams): List[OgcLayer] =
-    sources
-      .find(p.toQuery)
-      .map {
+  private val logger = org.log4s.getLogger
+
+  def getLayers(p: GetCoverageWcsParams): List[OgcLayer] = {
+    val filteredSources = sources.find(p.toQuery)
+    logger.debug(s"Filtering sources: ${sources.store.length} -> ${filteredSources.length}")
+    filteredSources.map {
         case SimpleSource(name, title, source, _, styles) =>
           SimpleOgcLayer(name, title, p.crs, source, None)
         case MapAlgebraSource(name, title, sources, algebra, _, styles) =>
           val simpleLayers = sources.mapValues { rs => SimpleOgcLayer(name, title, p.crs, rs, None) }
           MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra, None)
       }
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds basic temporal support for querying a single TimeInterval or TimePeriod for a given WCS layer. The spec supports querying over multiple intervals or periods but that's not really compatible with GT server currently returning a single raster for all GetCoverage requests. I opened #225 to address expanded temporal querying in the future.

Before calling this issue complete, I think we should still address the following:
- [x] ~~Generate or find a simple GeoTrellis layer with a temporal component that we can use for testing~~ Generated and a note added to #219. Further work to improve performance will happen there.
- [x] ~~Figure out how to get QGIS to include the temporal component when configured to render WCS layers~~ Looks to be not trivial. New issue created in our private team repo due to client specific concerns since it doesn't look like QGIS doesn't natively support temporal params on WCS layers.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

I again used the same LOCA RCP 85 climate data layer I used in #223 which has daily slices for one year.

GetCoverage request with a TimePeriod param `timesequence=2020-01-01T00:00:00Z` correctly filters to a single source available in the layer:
<img width="1263" alt="Screen Shot 2020-03-02 at 3 43 53 PM" src="https://user-images.githubusercontent.com/1818302/75725121-0adb8180-5c9d-11ea-8494-314afe741463.png">

GetCoverage request with a TimeInterval param `TIMESEQUENCE=2020-01-15T00:00:00Z/2020-02-15T00:00:00Z` correctly filters to the 31 slices valid during that range:
<img width="1265" alt="Screen Shot 2020-03-02 at 4 17 55 PM" src="https://user-images.githubusercontent.com/1818302/75727230-ae2e9580-5ca1-11ea-8d3d-46c1b5bf8490.png">

## Testing Instructions

Configure the same layer as in #223 (LOCA RCP85) and issue a GetCoverage request that includes the timesequence parameter such as:

http://localhost:9000/?SERVICE=WCS&VERSION=1.1.1&REQUEST=GetCoverage&FORMAT=image/geotiff&IDENTIFIER=loca-rcp85&TIMESEQUENCE=2020-01-01T00:00:00Z&BOUNDINGBOX=38.63767820773930595%2C-96.15608740894901985%2C38.76232179226069974%2C-95.84391259105098015%2Curn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&GRIDBASECRS=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&GRIDCS=urn%3Aogc%3Adef%3Acs%3AOGC%3A0.0%3AGrid2dSquareCS&GRIDTYPE=urn%3Aogc%3Adef%3Amethod%3AWCS%3A1.1%3A2dSimpleGrid&GRIDORIGIN=38.76232179226069974%2C-96.15608740894901985&GRIDOFFSETS=-0.06232179226069453%2C0.0624349635796051

This particular layer will timeout attempting to serve the query as it requires pulling a large sum of data across a tiled data source. 😞 I still haven't constructed or found a good test layer that includes a temporal dimension. 

Closes #157 
