### PR TITLE
Add Time Dimension to WMS GetCapabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {WCS|WMTS|WMS}Model uses RasterSource catalog [#163](https://github.com/geotrellis/geotrellis-server/issues/163)
 - WCS DescribeCoverage may include time TemporalDomain [#211](https://github.com/geotrellis/geotrellis-server/issues/211)
 - WCS GetCoverage may include time param `TIMESEQUENCE` [#157](https://github.com/geotrellis/geotrellis-server/issues/157)
+- WMS GetCapabilities may include time TemporalDomain [#230](https://github.com/geotrellis/geotrellis-server/issues/230)
 
 ### Changed
 - Included split dependencies a la GeoTrellis 3.2 for cats ecosystem libraries [\#184](https://github.com/geotrellis/geotrellis-server/pull/184)

--- a/ogc-example/src/main/resources/application-spacetimekey.conf
+++ b/ogc-example/src/main/resources/application-spacetimekey.conf
@@ -1,0 +1,220 @@
+wms = {
+  parent-layer-meta = {
+    name = "Geotrellis WMS Parent Layer"
+    title = "WMS Parent Title"
+    description = "Top level metadata that is inherited by children layers"
+    supported-projections = [
+      4326,
+      3410,
+      3978,
+      4617,
+      3979,
+      3413,
+      26916
+    ]
+  }
+  service-metadata = {
+    name = "WMS"
+    title = "GeoTrellis Service"
+    online-resource = {}
+    keyword-list = {
+      keyword = ["geotrellis", "catalog"]
+    }
+    contact-information = {
+      contact-person-primary = {
+        contact-person = "Eugene Cheipesh"
+        contact-organization = "Azavea"
+      }
+      contact-position = "Developer"
+      contact-address = {
+        address-type = "Office"
+        address = "990 Spring Garden St."
+        city = "Philadelphia"
+        state-or-province = "PA",
+        post-code = "19087",
+        country = "USA"
+      }
+    }
+  }
+  layer-definitions = [
+    ${layers.spacetimetest}
+  ]
+}
+
+wcs = {
+  service-metadata = {
+    identification = {
+      title = "WCS"
+      description = "Geotrellis WCS Service"
+      keywords = []
+      profile = ["http://azavea.com/wcs-profile"]
+      fees = ""
+      access-constraints = []
+    }
+    provider = {
+      name = "Azavea"
+      site = "https://www.azavea.com"
+    }
+  }
+  layer-definitions = [
+    ${layers.spacetimetest}
+  ]
+}
+
+wmts = {
+  service-metadata = {
+    identification = {
+      title = "WMTS"
+      description = "Geotrellis WMTS Service"
+      keywords = []
+      profile = ["http://azavea.com/wmts-profile"]
+      fees = ""
+      access-constraints = []
+    }
+    provider = {
+      name = "Azavea"
+      site = "https://www.azavea.com"
+    }
+  }
+  layer-definitions = []
+  tile-matrix-sets = [
+    {
+      identifier = "GoogleMapsCompatible",
+      supported-crs = 3857,
+      title = "GoogleMapCompatible",
+      abstract = "Google Maps compatible tile matrix set",
+      well-known-scale-set = "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible",
+      tile-matrix = [
+        {
+          identifier = "0",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [1, 1, 256, 256]
+        },
+        {
+          identifier = "1",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [2, 2, 256, 256]
+        },
+        {
+          identifier = "2",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [4, 4, 256, 256]
+        },
+        {
+          identifier = "3",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [8, 8, 256, 256]
+        },
+        {
+          identifier = "4",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [16, 16, 256, 256]
+        },
+        {
+          identifier = "5",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [32, 32, 256, 256]
+        },
+        {
+          identifier = "6",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [64, 64, 256, 256]
+        },
+        {
+          identifier = "7",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [128, 128, 256, 256]
+        },
+        {
+          identifier = "8",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [256, 256, 256, 256]
+        },
+        {
+          identifier = "9",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [512, 512, 256, 256]
+        },
+        {
+          identifier = "10",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [1024, 1024, 256, 256]
+        },
+        {
+          identifier = "11",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [2048, 2048, 256, 256]
+        },
+        {
+          identifier = "12",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [4096, 4096, 256, 256]
+        },
+        {
+          identifier = "13",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [8192, 8192, 256, 256]
+        },
+        {
+          identifier = "14",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [16384, 16384, 256, 256]
+        },
+        {
+          identifier = "15",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [32768, 32768, 256, 256]
+        },
+        {
+          identifier = "16",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [65536, 65536, 256, 256]
+        },
+        {
+          identifier = "17",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [131072, 131072, 256, 256]
+        },
+        {
+          identifier = "18",
+          extent = [-20037508.34278925, -20037508.34278925, 20037508.34278925, 20037508.34278925],
+          tile-layout = [262144, 262144, 256, 256]
+        }
+      ]
+    }
+  ]
+}
+
+layers = {
+  spacetimetest = {
+    type = "simplesourceconf"
+    name = "spacetimetest"
+    title = "Landsat 8 OGC Temporal SpaceTimeKey Test"
+    source = {
+      type = "geotrellis"
+      catalog-uri = "s3://geotrellis-test-non-public/spacetimekey-test"
+      layer = "spacetimekey-test"
+      zoom = 14
+      band-count = 1
+    }
+    styles = [
+      {
+        name = "red-to-blue"
+        title = "Red To Blue"
+        type = "colorrampconf"
+        colors = ${color-ramps.red-to-blue}
+        stops = 64
+      }
+    ]
+  }
+}
+
+color-ramps = {
+  "red-to-blue": [
+    0x2A2E7FFF, 0x3D5AA9FF, 0x4698D3FF, 0x39C6F0FF,
+    0x76C9B3FF, 0xA8D050FF, 0xF6EB14FF, 0xFCB017FF,
+    0xF16022FF, 0xEE2C24FF, 0x7D1416FF
+  ]
+}
+
+color-maps = {}


### PR DESCRIPTION
## Overview

Not much to add here...

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

Started the server with the newly committed application-spacetimekey.conf and got this back:

![Screen Shot 2020-03-12 at 3 27 27 PM](https://user-images.githubusercontent.com/1818302/76560041-ab3c5d80-6476-11ea-8062-0e5121fdf4ca.png)

## Notes

WMS, unlike WCS, has a parent layer that defines the ranges for all included child layers. The time range on this parent layer is derived from the min/max times in the child layers. The time interval _can_ have an "interval" component but I'm not generating that here. It would be far too difficult to generate the correct interval from an arbitrary list of individual date times. Interval is an optional part of the time spec anyways.

## Testing Instructions

`./sbt` followed by `project ogcExample` then
```
run --public-url http://127.0.0.1:9000 --interface 0.0.0.0 --port 9000 --conf src/main/resources/application-spacetimekey.conf
```

Can view the result at http://localhost:9000/?SERVICE=WMS&REQUEST=GetCapabilities
or by adding GT server as a new WMS layer in QGis.

Closes #185 
