### PR TITLE
WMS GetMap TIME Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {WCS|WMTS|WMS}Model uses RasterSource catalog [#163](https://github.com/geotrellis/geotrellis-server/issues/163)
 - WCS DescribeCoverage may include time TemporalDomain [#211](https://github.com/geotrellis/geotrellis-server/issues/211)
 - WCS GetCoverage may include time param `TIMESEQUENCE` [#157](https://github.com/geotrellis/geotrellis-server/issues/157)
-- WMS GetCapabilities may include time TemporalDomain [#230](https://github.com/geotrellis/geotrellis-server/issues/230)
+- WMS GetCapabilities may include time TemporalDomain [#185](https://github.com/geotrellis/geotrellis-server/issues/185)
 - WMS GetMap may include time param `TIME` [#175](https://github.com/geotrellis/geotrellis-server/issues/175)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WCS DescribeCoverage may include time TemporalDomain [#211](https://github.com/geotrellis/geotrellis-server/issues/211)
 - WCS GetCoverage may include time param `TIMESEQUENCE` [#157](https://github.com/geotrellis/geotrellis-server/issues/157)
 - WMS GetCapabilities may include time TemporalDomain [#230](https://github.com/geotrellis/geotrellis-server/issues/230)
+- WMS GetMap may include time param `TIME` [#175](https://github.com/geotrellis/geotrellis-server/issues/175)
 
 ### Changed
 - Included split dependencies a la GeoTrellis 3.2 for cats ecosystem libraries [\#184](https://github.com/geotrellis/geotrellis-server/pull/184)

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -24,13 +24,11 @@ import geotrellis.raster.CellSize
 import geotrellis.vector.Extent
 
 import cats.syntax.option._
-import jp.ne.opt.chronoscala.Imports._
 import opengis.wms._
 import opengis._
 import scalaxb._
 
 import java.net.URL
-import java.time.ZonedDateTime
 import scala.xml.Elem
 
 /**
@@ -159,12 +157,6 @@ object CapabilitiesView {
   }
 
   def modelAsLayer(parentLayerMeta: WmsParentLayerMeta, model: WmsModel): Layer = {
-    val times: List[ZonedDateTime] = model.sources.store.map(_.time).flatten
-    val timeInterval = times match {
-      case Nil => None
-      case head :: Nil => OgcTimeInterval(head).some
-      case list => OgcTimeInterval(list.min, Some(list.max), None).some
-    }
     Layer(
       Name        = parentLayerMeta.name,
       Title       = parentLayerMeta.title,
@@ -186,7 +178,7 @@ object CapabilitiesView {
       },
       // TODO: bounding box for global layer
       BoundingBox         = Nil,
-      Dimension           = timeInterval match {
+      Dimension           = model.temporalRange match {
         case Some(interval) => Seq(Dimension(
           interval.toString,
           Map(


### PR DESCRIPTION
## Overview

Adds the GetMap TIME parameter and supports default values based on parent layer configuration according to the spec referenced in #175.

This also fixes the Capabilities view so that the individual child layers do not return a `@default` attribute, since that only makes sense on the parent summary layer. 

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

The request:
http://127.0.0.1:9000/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&TIME=2019-11-14T00:00:00Z&BBOX=40.67416905012819228,-80.43073654174804688,42.82203597468244993,-77.60293832599259645&CRS=EPSG:4326&WIDTH=641&HEIGHT=487&LAYERS=spacetimetest&STYLES=&FORMAT=image/png&DPI=72&MAP_RESOLUTION=72&FORMAT_OPTIONS=dpi:72&TRANSPARENT=TRUE

Using application-spacetimekey.conf yields logging output indicating that we've correctly filtered the available WMS sources to the correct one:
```
10:12:38.321 [scala-execution-context-global-19] DEBUG geotrellis.server.ogc.wms.WmsModel - WMS time param: Some(2019-11-14T00:00:00Z)
10:12:38.401 [scala-execution-context-global-19] DEBUG geotrellis.server.ogc.wms.WmsModel - WMS source time: Some(2019-11-14T00:00Z)
```

Then for the same request without a TIME parameter provided we auto select the first time in the layer:
```
10:11:00.144 [scala-execution-context-global-19] DEBUG geotrellis.server.ogc.wms.WmsModel - WMS time param: Some(2019-05-06T00:00:00Z)    
10:11:00.247 [scala-execution-context-global-19] DEBUG geotrellis.server.ogc.wms.WmsModel - WMS source time: Some(2019-05-06T00:00Z)
```

### Notes

I put some useful notes in each commit message, probably worth a look.

## Testing Instructions

Make the same queries as indicated above. The following should be true:
- [ ] Temporal GetMap request with no TIME param returns result for default time specified in GetCapabilities request
- [ ] Temporal GetMap request with TIME param returns result for specified time
- [ ] Non-temporal GetMap request continues to behave as before
- [ ] Non-temporal GetMap request with TIME param should fail because its an invalid param

Other musings -- the above is written as a test spec, mocking all of the things necessary to test this was a large lift. We should definitely work towards more testing.

Closes #175 
