### PR TITLE
Bump MAML version up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Configurable ResampleMethod in source definitions [#229](https://github.com/geotrellis/geotrellis-server/issues/229)
+- Enable TargetCell parameter for focal operations [#212](https://github.com/geotrellis/geotrellis-server/issues/212)
 
 ## [4.1.0] - 2020-03-03
 

--- a/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
@@ -64,7 +64,7 @@ class HillshadeSpec extends FunSpec with Matchers {
       val hillshadeProjectedRaster = ProjectedRaster(raster, LatLng)
 
       val interpreter = Interpreter.DEFAULT
-      val res = interpreter(FocalHillshade(List(RasterLit(hillshadeProjectedRaster)), 315, 45, TargetCell.All)).as[MultibandTile]
+      val res = interpreter(FocalHillshade(List(RasterLit(hillshadeProjectedRaster)), 315, 45)).as[MultibandTile]
 
       res match {
         case Valid(t) => GeoTiff(Raster(t, raster.extent), LatLng).write("/tmp/rs-reproject-hillshade.tiff")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   val kamonPrometheus = "io.kamon" %% "kamon-prometheus" % "1.0.0"
   val kamonSysMetrics = "io.kamon" %% "kamon-system-metrics" % "1.0.0"
   val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0"
-  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0-5-gba9016b-SNAPSHOT"
+  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0-6-g0d936eb-SNAPSHOT"
   val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.12.2"
   val refined = "eu.timepit" %% "refined" % refinedVer
   val scaffeine = "com.github.blemale" %% "scaffeine" % "2.6.0"


### PR DESCRIPTION
## Overview

This PR bumps MAML version up.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

```
        algebra = {
          "args" : [
            {
              "args" : [
                {
                  "name" : "us-census-median-household-income",
                  "symbol" : "rasterV"
                }
              ],
              "neighborhood" : {
                "extent" : 1,
                "type" : "square"
              },
              "target" : "nodata",
              "symbol" : "fmax"
            },
            {
              "args" : [
                {
                  "name" : "us-census-median-household-income",
                  "symbol" : "rasterV"
                }
              ],
              "neighborhood" : {
                "extent" : 1,
                "type" : "square"
              },
              "target" : "nodata",
              "symbol" : "fmax"
            }
          ],
          "symbol" : "+"
        }
```

**data**:
![image](https://user-images.githubusercontent.com/4929546/77012941-5fd9f180-6945-11ea-8da7-4d4f7e5e1e0f.png)

**all**:
![image](https://user-images.githubusercontent.com/4929546/77013083-b21b1280-6945-11ea-91b3-246fa2f9c221.png)

Closes #212
