### PR TITLE
Expose RasterSource resample methods through configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable ResampleMethod in source definitions [#229](https://github.com/geotrellis/geotrellis-server/issues/229)
+
 ## [4.1.0] - 2020-03-03
 
 ### Added

--- a/core/src/main/scala/geotrellis/server/vlm/RasterSourceUtils.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/RasterSourceUtils.scala
@@ -18,7 +18,7 @@ package geotrellis.server.vlm
 
 import geotrellis.proj4.{CRS, WebMercator}
 import geotrellis.raster._
-import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.resample._
 import geotrellis.layer._
 
 import cats.effect.IO
@@ -33,6 +33,36 @@ trait RasterSourceUtils {
 
   implicit val uriEncoder: Encoder[URI] = Encoder.encodeString.contramap[URI](_.toString)
   implicit val uriDecoder: Decoder[URI] = Decoder[String].emap { str => Right(URI.create(str)) }
+
+  implicit val resampleMethodEncoder: Encoder[ResampleMethod] =
+    Encoder.encodeString.contramap[ResampleMethod] {
+      case NearestNeighbor  => "nearest-neighbor"
+      case Bilinear         => "bilinear"
+      case CubicConvolution => "cubic-convolution"
+      case CubicSpline      => "cubic-spline"
+      case Lanczos          => "lanczos"
+      case Average          => "average"
+      case Mode             => "mode"
+      case Median           => "median"
+      case Max              => "max"
+      case Min              => "min"
+      case Sum              => "sum"
+    }
+
+  implicit val resampleMethodDecoder: Decoder[ResampleMethod] =
+    Decoder.decodeString.map {
+      case "nearest-neighbor"  => NearestNeighbor
+      case "bilinear"          => Bilinear
+      case "cubic-convolution" => CubicConvolution
+      case "cubic-spline"      => CubicSpline
+      case "lanczos"           => Lanczos
+      case "average"           => Average
+      case "mode"              => Mode
+      case "median"            => Median
+      case "max"               => Max
+      case "min"               => Min
+      case "sum"               => Sum
+    }
 
   def getRasterSource(uri: String): RasterSource
 

--- a/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
+++ b/core/src/main/scala/geotrellis/server/vlm/geotiff/GeoTiffNode.scala
@@ -20,9 +20,9 @@ import geotrellis.server._
 import geotrellis.server.vlm._
 import geotrellis.proj4.WebMercator
 import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.geotiff.GeoTiffRasterSource
 import geotrellis.raster.io.geotiff.AutoHigherResolution
-
 import geotrellis.vector.Extent
 
 import _root_.io.circe._
@@ -32,7 +32,7 @@ import cats.data.{NonEmptyList => NEL}
 
 import java.net.URI
 
-case class GeoTiffNode(uri: URI, band: Int, celltype: Option[CellType], resampleMethod: ResampleMethod)
+case class GeoTiffNode(uri: URI, band: Int, celltype: Option[CellType], resampleMethod: ResampleMethod = NearestNeighbor)
 
 object GeoTiffNode extends RasterSourceUtils {
   def getRasterSource(uri: String): GeoTiffRasterSource = GeoTiffRasterSource(uri)

--- a/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
@@ -114,7 +114,7 @@ class GeoTrellisRasterSourceLegacy(
     if (targetCRS != this.crs) {
       val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
       val (closestLayerId, targetGridExtent) = GeoTrellisReprojectRasterSourceLegacy.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-      new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleTarget, time = time, targetCellType = targetCellType)
+      new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, resampleTarget, method, time = time, targetCellType = targetCellType)
     } else {
       // TODO: add unit tests for this in particular, the behavior feels murky
       resampleTarget match {

--- a/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacyProvider.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacyProvider.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package geotrellis.store
 

--- a/core/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSourceLegacy.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisReprojectRasterSourceLegacy.scala
@@ -154,15 +154,15 @@ class GeoTrellisReprojectRasterSourceLegacy(
   override def resample(resampleTarget: ResampleTarget, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
     val newReprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
     val (closestLayerId, newGridExtent) = GeoTrellisReprojectRasterSourceLegacy.getClosestSourceLayer(crs, sourceLayers, newReprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleTarget, time = time, targetCellType = targetCellType)
+    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, closestLayerId, sourceLayers, newGridExtent, crs, resampleTarget, method, time = time, targetCellType = targetCellType)
   }
 
   override def convert(targetCellType: TargetCellType): RasterSource = {
-    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, resampleTarget, time = time, targetCellType = Some(targetCellType))
+    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, layerId, sourceLayers, gridExtent, crs, resampleTarget, resampleMethod, time = time, targetCellType = Some(targetCellType))
   }
 
   override def toString: String =
-    s"GeoTrellisReprojectRasterSourceLegacy(${dataPath.value},$layerId,$crs,$gridExtent,${resampleMethod})"
+    s"GeoTrellisReprojectRasterSourceLegacy(${dataPath.value},$layerId,$crs,$gridExtent,$resampleMethod)"
 }
 
 object GeoTrellisReprojectRasterSourceLegacy {

--- a/core/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSourceLegacy.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisResampleRasterSourceLegacy.scala
@@ -110,8 +110,8 @@ class GeoTrellisResampleRasterSourceLegacy(
 
   override def reprojection(targetCRS: CRS, resampleTarget: ResampleTarget = DefaultTarget, method: ResampleMethod = NearestNeighbor, strategy: OverviewStrategy = AutoHigherResolution): GeoTrellisReprojectRasterSourceLegacy = {
     val reprojectOptions = ResampleTarget.toReprojectOptions(this.gridExtent, resampleTarget, method)
-    val (closestLayerId, gridExtent) = GeoTrellisReprojectRasterSourceLegacy.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
-    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, time = time, targetCellType = targetCellType)
+    val (_, gridExtent) = GeoTrellisReprojectRasterSourceLegacy.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
+    new GeoTrellisReprojectRasterSourceLegacy(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, resampleTarget, method, time = time, targetCellType = targetCellType)
   }
   /** Resample underlying RasterSource to new grid extent
    * Note: ResampleTarget will be applied to GridExtent of the source layer, not the GridExtent of this RasterSource

--- a/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
@@ -18,17 +18,16 @@ package geotrellis.server
 
 import geotrellis.raster._
 import geotrellis.vector._
-import geotrellis.raster.resample.NearestNeighbor
-
-import org.scalatest._
 
 import scala.concurrent.ExecutionContext
+
+import org.scalatest._
 
 class LayerExtentTest extends FunSuite with Matchers {
   implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
 
   test("ability to read a selected extent") {
-    val rt = ResourceTile("8x8.tif", NearestNeighbor)
+    val rt = ResourceTile("8x8.tif")
     val eval = LayerExtent.identity(rt)
     // We'll sample such that the bottom row (from 56 to 64) are excised from the result
     val sampled = eval(Extent(0, 1, 8, 8), CellSize(1, 1)).unsafeRunSync

--- a/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerExtentTest.scala
@@ -16,32 +16,24 @@
 
 package geotrellis.server
 
-import geotrellis.server.extent.SampleUtils
-
 import geotrellis.raster._
 import geotrellis.vector._
-import com.azavea.maml.error._
-import cats._
-import cats.effect._
-import cats.data.{NonEmptyList => NEL}
-import cats.implicits._
+import geotrellis.raster.resample.NearestNeighbor
 
 import org.scalatest._
 
-import scala.util.Random
 import scala.concurrent.ExecutionContext
-
 
 class LayerExtentTest extends FunSuite with Matchers {
   implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
 
   test("ability to read a selected extent") {
-    val rt = ResourceTile("8x8.tif")
+    val rt = ResourceTile("8x8.tif", NearestNeighbor)
     val eval = LayerExtent.identity(rt)
     // We'll sample such that the bottom row (from 56 to 64) are excised from the result
     val sampled = eval(Extent(0, 1, 8, 8), CellSize(1, 1)).unsafeRunSync
     val sample = sampled.toOption.get.band(0).toArray()
-    val sampleSum = sample.fold(0)(_ + _)
+    val sampleSum = sample.sum
     assert(sampleSum == 1596, s"Expected sum of 1596, got $sampleSum")
   }
 }

--- a/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
@@ -16,8 +16,6 @@
 
 package geotrellis.server
 
-import geotrellis.raster.resample.NearestNeighbor
-
 import org.scalatest._
 
 import scala.concurrent.ExecutionContext
@@ -27,21 +25,21 @@ class LayerHistogramTest extends FunSuite with Matchers {
 
   // This test works when the chosen sampling strategy is to work from the corners
   ignore("extents sampled from within overall extent") {
-    val rt = ResourceTile("8x8.tif", NearestNeighbor)
+    val rt = ResourceTile("8x8.tif")
     val samples = LayerHistogram.identity(rt, 4).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 4, s"Expected 4 cells in histogram, got $sampleCount")
   }
 
   test("histogram samples the total extent when budget is equal to the cell count") {
-    val rt = ResourceTile("8x8.tif", NearestNeighbor)
+    val rt = ResourceTile("8x8.tif")
     val samples = LayerHistogram.identity(rt, 64).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 64, s"Expected 64 cells in histogram, got $sampleCount")
   }
 
   test("histogram samples the total extent when budget too big") {
-    val rt = ResourceTile("8x8.tif", NearestNeighbor)
+    val rt = ResourceTile("8x8.tif")
     val samples = LayerHistogram.identity(rt, 128).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 64, s"Expected 64 cells in histogram, got $sampleCount")

--- a/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
+++ b/core/src/test/scala/geotrellis/server/LayerHistogramTest.scala
@@ -16,42 +16,32 @@
 
 package geotrellis.server
 
-import geotrellis.server.extent.SampleUtils
-
-import geotrellis.raster._
-import geotrellis.vector._
-import com.azavea.maml.error._
-import cats._
-import cats.implicits._
-import cats.effect._
-import cats.data.{NonEmptyList => NEL}
+import geotrellis.raster.resample.NearestNeighbor
 
 import org.scalatest._
 
-import scala.util.Random
 import scala.concurrent.ExecutionContext
-
 
 class LayerHistogramTest extends FunSuite with Matchers {
   implicit val cs = cats.effect.IO.contextShift(ExecutionContext.global)
 
   // This test works when the chosen sampling strategy is to work from the corners
   ignore("extents sampled from within overall extent") {
-    val rt = ResourceTile("8x8.tif")
+    val rt = ResourceTile("8x8.tif", NearestNeighbor)
     val samples = LayerHistogram.identity(rt, 4).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 4, s"Expected 4 cells in histogram, got $sampleCount")
   }
 
   test("histogram samples the total extent when budget is equal to the cell count") {
-    val rt = ResourceTile("8x8.tif")
+    val rt = ResourceTile("8x8.tif", NearestNeighbor)
     val samples = LayerHistogram.identity(rt, 64).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 64, s"Expected 64 cells in histogram, got $sampleCount")
   }
 
   test("histogram samples the total extent when budget too big") {
-    val rt = ResourceTile("8x8.tif")
+    val rt = ResourceTile("8x8.tif", NearestNeighbor)
     val samples = LayerHistogram.identity(rt, 128).unsafeRunSync
     val sampleCount = samples.toOption.get.head.statistics.get.dataCells
     assert(sampleCount == 64, s"Expected 64 cells in histogram, got $sampleCount")

--- a/core/src/test/scala/geotrellis/server/ResourceTile.scala
+++ b/core/src/test/scala/geotrellis/server/ResourceTile.scala
@@ -21,13 +21,12 @@ import geotrellis.raster._
 import geotrellis.raster.geotiff._
 import geotrellis.raster.io.geotiff.AutoHigherResolution
 import geotrellis.raster.resample.NearestNeighbor
-import geotrellis.proj4.WebMercator
 import geotrellis.vector.Extent
 
 import cats.effect._
 import cats.data.{NonEmptyList => NEL}
 
-case class ResourceTile(name: String, resampleMethod: ResampleMethod) {
+case class ResourceTile(name: String, resampleMethod: ResampleMethod = NearestNeighbor) {
   def uri = {
     val f = getClass.getResource(s"/$name").getFile
     s"file://$f"

--- a/core/src/test/scala/geotrellis/server/ResourceTile.scala
+++ b/core/src/test/scala/geotrellis/server/ResourceTile.scala
@@ -27,7 +27,7 @@ import geotrellis.vector.Extent
 import cats.effect._
 import cats.data.{NonEmptyList => NEL}
 
-case class ResourceTile(name: String) {
+case class ResourceTile(name: String, resampleMethod: ResampleMethod) {
   def uri = {
     val f = getClass.getResource(s"/$name").getFile
     s"file://$f"
@@ -41,7 +41,7 @@ object ResourceTile extends RasterSourceUtils {
     def extentReification(self: ResourceTile)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[ProjectedRaster[MultibandTile]] =
       (extent: Extent, cs: CellSize) => {
         val rs = getRasterSource(self.uri.toString)
-        rs.resample(TargetRegion(new GridExtent[Long](extent, cs)), NearestNeighbor, AutoHigherResolution)
+        rs.resample(TargetRegion(new GridExtent[Long](extent, cs)), self.resampleMethod, AutoHigherResolution)
           .read(extent)
           .map { raster => ProjectedRaster(raster, rs.crs) }
           .toIO { new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}") }

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -200,6 +200,7 @@ layers = {
         type = "simplesourceconf"
         name = "NLCD 2011",
         title = "National Land Cover Dataset 2011"
+        resample-method = "nearest-neighbor"
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=nlcd-2011-epsg3857&zoom=13&band_count=1"
         ]
@@ -243,6 +244,7 @@ layers = {
         type = "simplesourceconf"
         name = "us-census-median-household-income"
         title = "US Sensus Median Household Income 20??"
+        resample-method = "nearest-neighbor"
 
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=us-census-median-household-income-30m-epsg3857&zoom=12&band_count=1"
@@ -260,6 +262,7 @@ layers = {
         type = "simplesourceconf"
         name = "us-ned"
         title = "US NED"
+        resample-method = "nearest-neighbor"
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
         ]
@@ -277,6 +280,7 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "addition-house-income"
         title = "test addition"
+        resample-method = "nearest-neighbor"
         algebra = {
           "args" : [
             {
@@ -304,6 +308,7 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "us-ned-slope"
         title = "ned slope"
+        resample-method = "nearest-neighbor"
         algebra = {
           "args" : [
             {

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -41,6 +41,7 @@ wms = {
       ${layers.addition-house-income},
       ${layers.us-ned},
       ${layers.us-ned-slope},
+      ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income}
     ]
 }
@@ -63,6 +64,7 @@ wcs = {
     layer-definitions = [
       ${layers.us-ned},
       ${layers.us-ned-slope},
+      ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income}
     ]
 }
@@ -85,6 +87,7 @@ wmts = {
     layer-definitions = [
       ${layers.us-ned},
       ${layers.us-ned-slope},
+      ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income}
     ]
     tile-matrix-sets = [
@@ -307,7 +310,7 @@ layers = {
     us-ned-slope = {
         type = "mapalgebrasourceconf"
         name = "us-ned-slope"
-        title = "ned slope"
+        title = "US NED Slope"
         resample-method = "nearest-neighbor"
         algebra = {
           "args" : [
@@ -339,6 +342,33 @@ layers = {
                 ]
             }
         ]
+    }
+    us-ned-hillshade = {
+      type = "mapalgebrasourceconf"
+      name = "us-ned-hillshade"
+      title = "US NED Hillshade"
+      resample-method = "bilinear"
+      algebra = {
+        "args" : [
+          {
+            "name" : "us-ned",
+            "symbol" : "rasterV"
+          }
+        ],
+        "azimuth" : 315.0,
+        "altitude" : 45.0,
+        "target" : "data",
+        "symbol" : "fhillshade"
+      }
+      styles = [
+        {
+          type = "colorrampconf"
+          name = "red-to-blue"
+          title = "Red To Blue"
+          colors = ${color-ramps.red-to-blue}
+          stops = 64
+        }
+      ]
     }
 }
 

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -203,7 +203,6 @@ layers = {
         type = "simplesourceconf"
         name = "NLCD 2011",
         title = "National Land Cover Dataset 2011"
-        resample-method = "nearest-neighbor"
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=nlcd-2011-epsg3857&zoom=13&band_count=1"
         ]
@@ -247,7 +246,6 @@ layers = {
         type = "simplesourceconf"
         name = "us-census-median-household-income"
         title = "US Sensus Median Household Income 20??"
-        resample-method = "nearest-neighbor"
 
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=us-census-median-household-income-30m-epsg3857&zoom=12&band_count=1"
@@ -265,7 +263,6 @@ layers = {
         type = "simplesourceconf"
         name = "us-ned"
         title = "US NED"
-        resample-method = "nearest-neighbor"
         sources = [
             "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
         ]
@@ -283,7 +280,6 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "addition-house-income"
         title = "test addition"
-        resample-method = "nearest-neighbor"
         algebra = {
           "args" : [
             {
@@ -311,7 +307,6 @@ layers = {
         type = "mapalgebrasourceconf"
         name = "us-ned-slope"
         title = "US NED Slope"
-        resample-method = "nearest-neighbor"
         algebra = {
           "args" : [
             {

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -311,6 +311,7 @@ layers = {
               "symbol" : "rasterV"
             }
           ],
+          "target" : "all",
           "symbol" : "fslope"
         }
         styles = [

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,7 +107,7 @@ object Main extends CommandApp(
             simpleSources = conf
               .layers
               .values
-              .collect { case ssc@SimpleSourceConf(_, _, _, _, _) => ssc.models }
+              .collect { case ssc@SimpleSourceConf(_, _, _, _, _, _) => ssc.models }
               .toList
               .flatten
             _ <- Stream.eval(IO(logOptState(

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -29,9 +29,9 @@ sealed trait OgcServiceConf {
   def layerDefinitions: List[OgcSourceConf]
   def layerSources(simpleSources: List[SimpleSource]): OgcSourceRepository = {
     val simpleLayers =
-      layerDefinitions.collect { case ssc @ SimpleSourceConf(_, _, _, _, _) => ssc.models }.flatten
+      layerDefinitions.collect { case ssc @ SimpleSourceConf(_, _, _, _, _, _) => ssc.models }.flatten
     val mapAlgebraLayers =
-      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _) => masc.model(simpleSources) }
+      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _) => masc.model(simpleSources) }
     OgcSourceRepository(simpleLayers ++ mapAlgebraLayers)
   }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -17,17 +17,15 @@
 package geotrellis.server.ogc.conf
 
 import geotrellis.server.ogc._
+import geotrellis.raster.{RasterSource, ResampleMethod}
 
-import geotrellis.raster.RasterSource
 import com.azavea.maml.ast._
-import cats._
-import cats.implicits._
-
 
 // This sumtype corresponds to the in-config representation of a source
 sealed trait OgcSourceConf {
   def name: String
   def styles: List[StyleConf]
+  def resampleMethod: ResampleMethod
 }
 
 case class SimpleSourceConf(
@@ -35,11 +33,12 @@ case class SimpleSourceConf(
   title: String,
   sources: List[String],
   defaultStyle: Option[String],
-  styles: List[StyleConf]
+  styles: List[StyleConf],
+  resampleMethod: ResampleMethod
 ) extends OgcSourceConf {
   def models: List[SimpleSource] =
     sources.map(uri =>
-      SimpleSource(name, title, RasterSource(uri), defaultStyle, styles.map(_.toStyle)))
+      SimpleSource(name, title, RasterSource(uri), defaultStyle, styles.map(_.toStyle), resampleMethod))
 }
 
 case class MapAlgebraSourceConf(
@@ -47,7 +46,8 @@ case class MapAlgebraSourceConf(
   title: String,
   algebra: Expression,
   defaultStyle: Option[String],
-  styles: List[StyleConf]
+  styles: List[StyleConf],
+  resampleMethod: ResampleMethod
 ) extends OgcSourceConf {
   private def listParams(expr: Expression): List[String] = {
     def eval(subExpr: Expression): List[String] = subExpr match {
@@ -73,7 +73,7 @@ case class MapAlgebraSourceConf(
       }
       name -> layerSrc.source
     }
-    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle))
+    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod)
   }
 
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -18,7 +18,7 @@ package geotrellis.server.ogc.conf
 
 import geotrellis.server.ogc._
 import geotrellis.raster.{RasterSource, ResampleMethod}
-
+import geotrellis.raster.resample.NearestNeighbor
 import com.azavea.maml.ast._
 
 // This sumtype corresponds to the in-config representation of a source
@@ -34,7 +34,7 @@ case class SimpleSourceConf(
   sources: List[String],
   defaultStyle: Option[String],
   styles: List[StyleConf],
-  resampleMethod: ResampleMethod
+  resampleMethod: ResampleMethod = NearestNeighbor
 ) extends OgcSourceConf {
   def models: List[SimpleSource] =
     sources.map(uri =>
@@ -47,7 +47,7 @@ case class MapAlgebraSourceConf(
   algebra: Expression,
   defaultStyle: Option[String],
   styles: List[StyleConf],
-  resampleMethod: ResampleMethod
+  resampleMethod: ResampleMethod = NearestNeighbor
 ) extends OgcSourceConf {
   private def listParams(expr: Expression): List[String] = {
     def eval(subExpr: Expression): List[String] = subExpr match {

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -18,10 +18,9 @@ package geotrellis.server.ogc
 
 import geotrellis.server.ogc.wms.wmsScope
 import geotrellis.server.ogc.style._
-
 import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
-import geotrellis.raster.TileLayout
+import geotrellis.raster.{ResampleMethod, TileLayout, resample}
 import geotrellis.raster.render.{ColorMap, ColorRamp}
 
 import com.azavea.maml.ast._
@@ -151,6 +150,21 @@ package object conf {
         case Some(layout) => layout
         case None => throw new Exception(s"Invalid layout: $layout. Should be (layoutCols, layoutRows, tileCols, tileRows)")
       }
+    }
+
+  implicit val resampleMethodReader: ConfigReader[ResampleMethod] =
+    ConfigReader[String].map {
+      case "nearest-neighbor"  => resample.NearestNeighbor
+      case "bilinear"          => resample.Bilinear
+      case "cubic-convolution" => resample.CubicConvolution
+      case "cubic-spline"      => resample.CubicSpline
+      case "lanczos"           => resample.Lanczos
+      case "average"           => resample.Average
+      case "mode"              => resample.Mode
+      case "median"            => resample.Median
+      case "max"               => resample.Max
+      case "min"               => resample.Min
+      case "sum"               => resample.Sum
     }
 
   /** An alternative AST reading strategy that uses a separate json file */

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
@@ -65,16 +65,16 @@ class WmsView(wmsModel: WmsModel, serviceUrl: URL) {
         val re = RasterExtent(wmsReq.boundingBox, wmsReq.width, wmsReq.height)
         wmsModel.getLayer(wmsReq).map { layer =>
           val evalExtent = layer match {
-            case sl @ SimpleOgcLayer(_, _, _, _, _) =>
+            case sl @ SimpleOgcLayer(_, _, _, _, _, _) =>
               LayerExtent.identity(sl)
-            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _) =>
+            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _) =>
               LayerExtent(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO])
           }
 
           val evalHisto = layer match {
-            case sl @ SimpleOgcLayer(_, _, _, _, _) =>
+            case sl @ SimpleOgcLayer(_, _, _, _, _, _) =>
               LayerHistogram.identity(sl, 512)
-            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _) =>
+            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _) =>
               LayerHistogram(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO], 512)
           }
 

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -60,16 +60,16 @@ class WmtsView(wmtsModel: WmtsModel, serviceUrl: URL) {
           val layerName = wmtsReq.layer
           wmtsModel.getLayer(wmtsReq).map { layer =>
             val evalWmts = layer match {
-              case sl @ SimpleTiledOgcLayer(_, _, _, _, _, _) =>
+              case sl @ SimpleTiledOgcLayer(_, _, _, _, _, _, _) =>
                 LayerTms.identity(sl)
-              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _) =>
+              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _) =>
                 LayerTms(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO])
             }
 
             val evalHisto = layer match {
-              case sl@SimpleTiledOgcLayer(_, _, _, _, _, _) =>
+              case sl@SimpleTiledOgcLayer(_, _, _, _, _, _, _) =>
                 LayerHistogram.identity(sl, 512)
-              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _) =>
+              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _) =>
                 LayerHistogram(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO], 512)
             }
 

--- a/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
@@ -1,0 +1,59 @@
+package geotrellis.server
+
+import com.azavea.maml.ast.{FocalHillshade, RasterLit}
+import com.azavea.maml.error.Interpreted
+import com.azavea.maml.eval.{Interpreter, Result}
+
+import geotrellis.proj4.LatLng
+import geotrellis.raster.{MultibandTile, ProjectedRaster, Raster, RasterExtent, TargetCell}
+import geotrellis.raster.io.geotiff.{AutoHigherResolution, GeoTiff}
+import geotrellis.store._
+import geotrellis.raster.resample._
+import geotrellis.vector.Extent
+import cats.data.Validated.{Invalid, Valid}
+
+import scala.reflect.ClassTag
+
+import org.scalatest.FunSpec
+import org.scalatest._
+
+class HillshadeSpec extends FunSpec with Matchers {
+  implicit class TypeRefinement(self: Interpreted[Result]) {
+    def as[T: ClassTag]: Interpreted[T] = self match {
+      case Valid(r) => r.as[T]
+      case i @ Invalid(_) => i
+    }
+  }
+
+  // https://github.com/geotrellis/geotrellis-server/issues/150
+  describe("HillshadeSpec") {
+    ignore("RasterSource reproject hillshade") {
+      val uri = "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
+      val rs = new GeoTrellisRasterSourceLegacy(uri)
+      val raster =
+        rs
+          .reprojectToRegion(
+            LatLng,
+            RasterExtent(
+              Extent(-120.2952713630537, 39.13161870369179, -120.1235160949708, 39.25813307365495),
+              2.0018096513158E-4,2.0018096513159E-4,
+              858, 632
+            ),
+            Bilinear,
+            AutoHigherResolution
+          )
+          .read(Extent(-120.2952713630537, 39.13161870369179, -120.1235160949708, 39.25813307365495))
+          .get
+
+      val hillshadeProjectedRaster = ProjectedRaster(raster, LatLng)
+
+      val interpreter = Interpreter.DEFAULT
+      val res = interpreter(FocalHillshade(List(RasterLit(hillshadeProjectedRaster)), 315, 45, TargetCell.All)).as[MultibandTile]
+
+      res match {
+        case Valid(t) => GeoTiff(Raster(t, raster.extent), LatLng).write("/tmp/rs-reproject-hillshade.tiff")
+        case i@Invalid(_) => fail(s"$i")
+      }
+    }
+  }
+}

--- a/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
+++ b/ogc-example/src/test/scala/geotrellis/server/HillshadeSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server
 
 import com.azavea.maml.ast.{FocalHillshade, RasterLit}

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
@@ -51,6 +51,7 @@ trait OgcSource {
   def metadata: RasterMetadata
   def attributes: Map[String, String]
   def time: Option[ZonedDateTime]
+  def resampleMethod: ResampleMethod
 
   def nativeProjectedExtent: ProjectedExtent = ProjectedExtent(nativeExtent, nativeCrs.head)
 }
@@ -63,7 +64,8 @@ case class SimpleSource(
   title: String,
   source: RasterSource,
   defaultStyle: Option[String],
-  styles: List[OgcStyle]
+  styles: List[OgcStyle],
+  resampleMethod: ResampleMethod
 ) extends OgcSource {
   def extentIn(crs: CRS): Extent = {
     val reprojected = source.reproject(crs)
@@ -107,7 +109,8 @@ case class MapAlgebraSource(
   sources: Map[String, RasterSource],
   algebra: Expression,
   defaultStyle: Option[String],
-  styles: List[OgcStyle]
+  styles: List[OgcStyle],
+  resampleMethod: ResampleMethod
 ) extends OgcSource {
   def extentIn(crs: CRS): Extent = {
     val reprojectedSources: NEL[RasterSource] =

--- a/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
@@ -20,6 +20,7 @@ import geotrellis.server._
 import geotrellis.server.ogc.style.OgcStyle
 import geotrellis.layer._
 import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.reproject.ReprojectRasterExtent
 import geotrellis.raster.reproject.Reproject.Options
 import geotrellis.vector.Extent
@@ -51,7 +52,7 @@ case class SimpleTiledOgcLayer(
   layout: LayoutDefinition,
   source: RasterSource,
   style: Option[OgcStyle],
-  resampleMethod: ResampleMethod
+  resampleMethod: ResampleMethod = NearestNeighbor
 ) extends TiledOgcLayer
 
 case class MapAlgebraTiledOgcLayer(
@@ -62,7 +63,7 @@ case class MapAlgebraTiledOgcLayer(
   parameters: Map[String, SimpleTiledOgcLayer],
   algebra: Expression,
   style: Option[OgcStyle],
-  resampleMethod: ResampleMethod
+  resampleMethod: ResampleMethod = NearestNeighbor
 ) extends TiledOgcLayer
 
 object SimpleTiledOgcLayer {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
@@ -21,6 +21,7 @@ import geotrellis.server.ogc.ows.OwsDataRecord
 import geotrellis.server.ogc.gml.GmlDataRecord
 import geotrellis.proj4.LatLng
 import geotrellis.raster.reproject.ReprojectRasterExtent
+import geotrellis.raster.reproject.Reproject.Options
 import geotrellis.raster.{Dimensions, GridExtent}
 import geotrellis.server.ogc.{MapAlgebraSource, OgcSource, SimpleSource, URN}
 import cats.syntax.option._
@@ -32,7 +33,6 @@ import opengis._
 
 import scala.xml.Elem
 import scalaxb._
-
 import java.net.{URI, URL}
 
 class CoverageView(
@@ -61,11 +61,11 @@ object CoverageView {
     val nativeCrs = source.nativeCrs.head
     val re = source.nativeRE
     val llre = source match {
-      case SimpleSource(_, _, rs, _, _) =>
-        ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng)
-      case MapAlgebraSource(_, _, rss, _, _, _) =>
+      case SimpleSource(_, _, rs, _, _, resampleMethod) =>
+        ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng, Options.DEFAULT.copy(resampleMethod))
+      case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod) =>
         rss.values.map { rs =>
-          ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng)
+          ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng, Options.DEFAULT.copy(resampleMethod))
         }.reduce({ (re1, re2) =>
           val e = re1.extent combine re2.extent
           val cs = if (re1.cellSize.resolution < re2.cellSize.resolution) re1.cellSize else re2.cellSize

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
@@ -60,8 +60,8 @@ class GetCoverage(wcsModel: WcsModel) {
           .getLayers(params)
           .headOption
           .map {
-            case so @ SimpleOgcLayer(_, _, _, _, _) => LayerExtent.identity(so)
-            case MapAlgebraOgcLayer(_, _, _, simpleLayers, algebra, _) =>
+            case so @ SimpleOgcLayer(_, _, _, _, _, _) => LayerExtent.identity(so)
+            case MapAlgebraOgcLayer(_, _, _, simpleLayers, algebra, _, _) =>
               LayerExtent(IO.pure(algebra), IO.pure(simpleLayers), ConcurrentInterpreter.DEFAULT)
           }
           .traverse { eval =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -30,11 +30,11 @@ case class WcsModel(
     val filteredSources = sources.find(p.toQuery)
     logger.debug(s"Filtering sources: ${sources.store.length} -> ${filteredSources.length}")
     filteredSources.map {
-        case SimpleSource(name, title, source, _, styles) =>
-          SimpleOgcLayer(name, title, p.crs, source, None)
-        case MapAlgebraSource(name, title, sources, algebra, _, styles) =>
-          val simpleLayers = sources.mapValues { rs => SimpleOgcLayer(name, title, p.crs, rs, None) }
-          MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra, None)
+        case SimpleSource(name, title, source, _, styles, resampleMethod) =>
+          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod)
+        case MapAlgebraSource(name, title, sources, algebra, _, styles, resampleMethod) =>
+          val simpleLayers = sources.mapValues { rs => SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod) }
+          MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra, None, resampleMethod)
       }
   }
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -64,13 +64,13 @@ case class WmsModel(
       val style: Option[OgcStyle] =
         styleName.flatMap { name => source.styles.find(_.name == name) }
       source match {
-        case MapAlgebraSource(name, title, rasterSources, algebra, defaultStyle, styles) =>
+        case MapAlgebraSource(name, title, rasterSources, algebra, defaultStyle, styles, resampleMethod) =>
           val simpleLayers = rasterSources.mapValues { rs =>
-            SimpleOgcLayer(name, title, supportedCrs, rs, style)
+            SimpleOgcLayer(name, title, supportedCrs, rs, style, resampleMethod)
           }
-          MapAlgebraOgcLayer(name, title, supportedCrs, simpleLayers, algebra, style)
-        case SimpleSource(name, title, rasterSource, defaultStyle, styles) =>
-          SimpleOgcLayer(name, title, supportedCrs, rasterSource, style)
+          MapAlgebraOgcLayer(name, title, supportedCrs, simpleLayers, algebra, style, resampleMethod)
+        case SimpleSource(name, title, rasterSource, defaultStyle, styles, resampleMethod) =>
+          SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod)
       }
     }
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -44,13 +44,13 @@ case class WmtsModel(
     } yield {
       val style: Option[OgcStyle] = source.styles.find(_.name == p.style)
       source match {
-        case MapAlgebraSource(name, title, rasterSources, algebra, _, styles) =>
+        case MapAlgebraSource(name, title, rasterSources, algebra, _, styles, resampleMethod) =>
           val simpleLayers = rasterSources.mapValues { rs =>
-            SimpleTiledOgcLayer(name, title, crs, layout, rs, style)
+            SimpleTiledOgcLayer(name, title, crs, layout, rs, style, resampleMethod)
           }
-          MapAlgebraTiledOgcLayer(name, title, crs, layout, simpleLayers, algebra, style)
-        case SimpleSource(name, title, rasterSource, _, styles) =>
-          SimpleTiledOgcLayer(name, title, crs, layout, rasterSource, style)
+          MapAlgebraTiledOgcLayer(name, title, crs, layout, simpleLayers, algebra, style, resampleMethod)
+        case SimpleSource(name, title, rasterSource, _, styles, resampleMethod) =>
+          SimpleTiledOgcLayer(name, title, crs, layout, rasterSource, style, resampleMethod)
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   val kamonPrometheus = "io.kamon" %% "kamon-prometheus" % "1.0.0"
   val kamonSysMetrics = "io.kamon" %% "kamon-system-metrics" % "1.0.0"
   val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0"
-  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0"
+  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.0-5-gba9016b-SNAPSHOT"
   val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.12.2"
   val refined = "eu.timepit" %% "refined" % refinedVer
   val scaffeine = "com.github.blemale" %% "scaffeine" % "2.6.0"


### PR DESCRIPTION
## Overview

This PR adds resample method as a cofigurable application.conf option

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

![bilinear-nn](https://user-images.githubusercontent.com/4929546/77214300-ed077c80-6ae4-11ea-976e-61fefbaf903d.gif)

It's also possible to view it via QGIS & a GeoTrellis server instance:

```bash
$ ./sbt
> project ogcExamples
> run --public-url http://localhost:9000/
```

Select the `us-ned-hillshade` WMS/WMTS/WCS layer!

Closes #229
Closes #150