### PR TITLE
[WIP] Temporal improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  
 - The `layers.layer-name.sources` field in application.conf is renamed to `source` and now supports a single RasterSource URI string. See `ogc-example/src/main/resources/application.conf` for examples. 
+- `type = "simplesourceconf"` should be changed to `type = "rastersourceconf"` in application.conf
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Added
 - Configurable ResampleMethod in source definitions [#229](https://github.com/geotrellis/geotrellis-server/issues/229)
 - Enable TargetCell parameter for focal operations [#212](https://github.com/geotrellis/geotrellis-server/issues/212)
+
+### Changed
+ 
+- The `layers.layer-name.sources` field in application.conf is renamed to `source` and now supports a single RasterSource URI string. See `ogc-example/src/main/resources/application.conf` for examples. 
+
+### Fixed
+
+- Addressed GeoTrellisRasterSourceLegacy issues and minimized number of RasterSource instances constructed for GeoTrellis Layers [#219](https://github.com/geotrellis/geotrellis-server/issues/219)
 
 ## [4.1.0] - 2020-03-03
 

--- a/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
@@ -22,11 +22,11 @@ import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
 import geotrellis.raster._
 import geotrellis.layer._
 import geotrellis.layer.filter._
-import geotrellis.store.index.hilbert.HilbertSpaceTimeKeyIndex
-import geotrellis.store.index.zcurve.ZSpaceTimeKeyIndex
+import geotrellis.store.query.CirceCompat._
 import geotrellis.vector._
+import jp.ne.opt.chronoscala.Imports._
 
-import java.time.{ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 case class LayerLegacy(id: LayerId, metadata: TileLayerMetadata[_], bandCount: Int) {
   /** GridExtent of the data pixels in the layer */
@@ -48,8 +48,9 @@ class GeoTrellisRasterSourceLegacy(
   val attributeStore: AttributeStore,
   val dataPath: GeoTrellisPath,
   val sourceLayers: Stream[LayerLegacy],
+  val targetCellType: Option[TargetCellType],
   val time: Option[ZonedDateTime],
-  val targetCellType: Option[TargetCellType]
+  val timeMetadataKey: String = "times"
 ) extends RasterSource {
   import GeoTrellisRasterSourceLegacy._
   def name: GeoTrellisPath = dataPath
@@ -67,10 +68,15 @@ class GeoTrellisRasterSourceLegacy(
 
   def layerId: LayerId = dataPath.layerId
 
+  private val logger = org.log4s.getLogger
+
   lazy val reader = CollectionLayerReader(attributeStore, dataPath.value)
 
   // read metadata directly instead of searching sourceLayers to avoid unneeded reads
-  lazy val layerMetadata: TileLayerMetadata[_] = reader.attributeStore.readMetadataErased(layerId)
+  lazy val layerMetadata: TileLayerMetadata[_] = {
+    logger.debug(s"RasterSource(${dataPath.value}): Reading layerMetadata")
+    reader.attributeStore.readMetadataErased(layerId)
+  }
 
   lazy val gridExtent: GridExtent[Long] = layerMetadata.layout.createAlignedGridExtent(layerMetadata.extent)
 
@@ -94,6 +100,18 @@ class GeoTrellisRasterSourceLegacy(
 
   // reference to this will fully initilze the sourceLayers stream
   lazy val resolutions: List[CellSize] = sourceLayers.map(_.gridExtent.cellSize).toList
+
+  lazy val times: List[ZonedDateTime] = {
+    val layerId = dataPath.layerId
+    val header = attributeStore.readHeader[LayerHeader](layerId)
+    if (header.keyClass.contains("SpaceTimeKey")) {
+      attributeStore.read[List[ZonedDateTime]](layerId, "times").sorted
+    } else {
+      List.empty[ZonedDateTime]
+    }
+  }
+
+  lazy val isTemporal: Boolean = times.nonEmpty
 
   override def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
     GeoTrellisRasterSourceLegacy.read(reader, layerId, layerMetadata, extent, bands).map(convertRaster)
@@ -136,7 +154,7 @@ class GeoTrellisRasterSourceLegacy(
   }
 
   override def convert(targetCellType: TargetCellType): RasterSource =
-    new GeoTrellisRasterSourceLegacy(attributeStore, dataPath, sourceLayers, time, Some(targetCellType))
+    new GeoTrellisRasterSourceLegacy(attributeStore, dataPath, sourceLayers, Some(targetCellType), time)
 
   override def toString: String =
     s"GeoTrellisRasterSourceLegacy($dataPath, $layerId)"
@@ -257,53 +275,20 @@ object GeoTrellisRasterSourceLegacy {
     }
   }
 
-  /**
-   * Build function that can build a list of RasterSources
-   * slicing them by time (in case of a temporal raster source).
-   *
-   * @param attributeStore GeoTrellis attribute store
-   * @param dataPath       GeoTrellis catalog DataPath
-   * @param sourceLayers   List of source layers
-   * @param tResolution    Layer temporal resolution, if not provided the function will try to derive it.
-   * @param targetCellType The target cellType
-   */
-  def build(
-    attributeStore: AttributeStore,
-    dataPath: GeoTrellisPath,
-    sourceLayers: Stream[LayerLegacy],
-    tResolution: Option[Long],
-    targetCellType: Option[TargetCellType]
-  ): List[GeoTrellisRasterSourceLegacy] = {
-    val layerId = dataPath.layerId
-    val header = attributeStore.readHeader[LayerHeader](layerId)
+  def apply(dataPath: GeoTrellisPath): GeoTrellisRasterSourceLegacy = GeoTrellisRasterSourceLegacy(dataPath, None, None)
 
-    if(header.keyClass.contains("SpatialKey"))
-      new GeoTrellisRasterSourceLegacy(attributeStore, dataPath, sourceLayers, None, targetCellType) :: Nil
-    else {
-      val md = attributeStore.readMetadata[TileLayerMetadata[SpaceTimeKey]](layerId)
-      val keyIndex = attributeStore.readKeyIndex[SpaceTimeKey](layerId)
-      val temporalResolution = tResolution.getOrElse(keyIndex match {
-        case ki if ki.isInstanceOf[ZSpaceTimeKeyIndex]       => ki.asInstanceOf[ZSpaceTimeKeyIndex].temporalResolution
-        case ki if ki.isInstanceOf[HilbertSpaceTimeKeyIndex] => ki.asInstanceOf[ZSpaceTimeKeyIndex].temporalResolution
-        case ki => throw new UnsupportedOperationException(s"Can't derive layer temporal resolution for ${ki.getClass}, try to pass a tResolution parameter explicitly.")
-      })
+  def apply(dataPath: GeoTrellisPath, time: Option[ZonedDateTime]): GeoTrellisRasterSourceLegacy = GeoTrellisRasterSourceLegacy(dataPath, time, None)
 
-      md.bounds match {
-        case KeyBounds(minKey, maxKey) =>
-          (minKey.time.toInstant.toEpochMilli to maxKey.time.toInstant.toEpochMilli by temporalResolution).toList.map { time =>
-            new GeoTrellisRasterSourceLegacy(attributeStore, dataPath, sourceLayers, Some(ZonedDateTime.ofInstant(time, ZoneOffset.UTC)), targetCellType)
-          }
-        case _ => Nil
-      }
-    }
-  }
-
-  def build(attributeStore: AttributeStore, dataPath: GeoTrellisPath): List[GeoTrellisRasterSourceLegacy] =
-    build(
-      attributeStore, dataPath,
-      GeoTrellisRasterSourceLegacy.getSourceLayersByName(attributeStore, dataPath.layerName, dataPath.bandCount.getOrElse(1)),
-      None, None
+  def apply(dataPath: GeoTrellisPath, time: Option[ZonedDateTime], targetCellType: Option[TargetCellType]): GeoTrellisRasterSourceLegacy = {
+    val attributeStore = AttributeStore(dataPath.value)
+    new GeoTrellisRasterSourceLegacy(
+      attributeStore,
+      dataPath,
+      GeoTrellisRasterSourceLegacy.getSourceLayersByName(
+        attributeStore, dataPath.layerName, dataPath.bandCount.getOrElse(1)
+      ),
+      targetCellType,
+      time
     )
-
-  def build(dataPath: GeoTrellisPath): List[GeoTrellisRasterSourceLegacy] = build(AttributeStore(dataPath.value), dataPath)
+  }
 }

--- a/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
+++ b/core/src/main/scala/geotrellis/store/GeoTrellisRasterSourceLegacy.scala
@@ -22,7 +22,6 @@ import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
 import geotrellis.raster._
 import geotrellis.layer._
 import geotrellis.layer.filter._
-import geotrellis.store.query.CirceCompat._
 import geotrellis.vector._
 import jp.ne.opt.chronoscala.Imports._
 

--- a/ogc-example/src/main/resources/application-spacetimekey.conf
+++ b/ogc-example/src/main/resources/application-spacetimekey.conf
@@ -187,16 +187,10 @@ wmts = {
 
 layers = {
   spacetimetest = {
-    type = "simplesourceconf"
+    type = "rastersourceconf"
     name = "spacetimetest"
     title = "Landsat 8 OGC Temporal SpaceTimeKey Test"
-    source = {
-      type = "geotrellis"
-      catalog-uri = "s3://geotrellis-test-non-public/spacetimekey-test"
-      layer = "spacetimekey-test"
-      zoom = 14
-      band-count = 1
-    }
+    source = "gt+s3://geotrellis-test-non-public/spacetimekey-test?layer=spacetimekey-test&zoom=14&band_count=1"
     styles = [
       {
         name = "red-to-blue"

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -200,12 +200,10 @@ wmts = {
 
 layers = {
     nlcd-2011 = {
-        type = "simplesourceconf"
+        type = "rastersourceconf"
         name = "NLCD 2011",
         title = "National Land Cover Dataset 2011"
-        sources = [
-            "gt+s3://azavea-datahub/catalog?layer=nlcd-2011-epsg3857&zoom=13&band_count=1"
-        ]
+        source = "gt+s3://azavea-datahub/catalog?layer=nlcd-2011-epsg3857&zoom=13&band_count=1"
 
         default-style = "red-to-blue"
         styles = [
@@ -243,13 +241,11 @@ layers = {
         ]
     }
     us-census-median-household-income = {
-        type = "simplesourceconf"
+        type = "rastersourceconf"
         name = "us-census-median-household-income"
         title = "US Sensus Median Household Income 20??"
 
-        sources = [
-            "gt+s3://azavea-datahub/catalog?layer=us-census-median-household-income-30m-epsg3857&zoom=12&band_count=1"
-        ]
+        source = "gt+s3://azavea-datahub/catalog?layer=us-census-median-household-income-30m-epsg3857&zoom=12&band_count=1"
         styles = [
             {
                 name = "interpolated-income"
@@ -260,12 +256,10 @@ layers = {
         ]
     }
     us-ned = {
-        type = "simplesourceconf"
+        type = "rastersourceconf"
         name = "us-ned"
         title = "US NED"
-        sources = [
-            "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
-        ]
+        source = "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
         styles = [
           {
             type = "colorrampconf"

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,9 +107,8 @@ object Main extends CommandApp(
             simpleSources = conf
               .layers
               .values
-              .collect { case ssc@SimpleSourceConf(_, _, _, _, _, _) => ssc.models }
+              .collect { case rsc@RasterSourceConf(_, _, _, _, _, _) => rsc.toLayer }
               .toList
-              .flatten
             _ <- Stream.eval(IO(logOptState(
               conf.wms,
               ansi"%green{WMS configuration detected}, starting Web Map Service",

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -16,7 +16,8 @@
 
 package geotrellis.server.ogc.conf
 
-import geotrellis.server.ogc.{OgcSourceRepository, SimpleSource, ows}
+import geotrellis.server.ogc
+import geotrellis.server.ogc.{MapAlgebraSource, OgcSourceRepository, RasterOgcSource, ows}
 import geotrellis.server.ogc.wms.WmsParentLayerMeta
 import geotrellis.server.ogc.wmts.GeotrellisTileMatrixSet
 
@@ -27,12 +28,12 @@ import geotrellis.server.ogc.wmts.GeotrellisTileMatrixSet
  */
 sealed trait OgcServiceConf {
   def layerDefinitions: List[OgcSourceConf]
-  def layerSources(simpleSources: List[SimpleSource]): OgcSourceRepository = {
-    val simpleLayers =
-      layerDefinitions.collect { case ssc @ SimpleSourceConf(_, _, _, _, _, _) => ssc.models }.flatten
-    val mapAlgebraLayers =
-      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _) => masc.model(simpleSources) }
-    OgcSourceRepository(simpleLayers ++ mapAlgebraLayers)
+  def layerSources(rasterOgcSources: List[RasterOgcSource]): OgcSourceRepository = {
+    val rasterLayers: List[RasterOgcSource] =
+      layerDefinitions.collect { case rsc @ RasterSourceConf(_, _, _, _, _, _) => rsc.toLayer }
+    val mapAlgebraLayers: List[MapAlgebraSource] =
+      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _) => masc.model(rasterOgcSources) }
+    ogc.OgcSourceRepository(rasterLayers ++ mapAlgebraLayers)
   }
 }
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
@@ -30,8 +30,8 @@ import cats.data.{NonEmptyList => NEL}
 import geotrellis.raster.reproject.Reproject.Options
 
 /**
- * Layer instances are sufficent to produce displayed the end product of 'get map'
- *  requests. They are produced in [[RasterSourcesModel]] from a combination of a WMS 'GetMap'
+ * OgcLayer instances are sufficient to produce visual rasters as the end product of 'get map'
+ *  requests. They are produced from a combination of a WMS 'GetMap'
  *  (or whatever the analogous request in whatever OGC service is being produced) and an instance
  *  of [[OgcSource]]
  */
@@ -43,6 +43,10 @@ sealed trait OgcLayer {
   def resampleMethod: ResampleMethod
 }
 
+sealed trait RasterOgcLayer {
+  def source: RasterSource
+}
+
 case class SimpleOgcLayer(
   name: String,
   title: String,
@@ -50,7 +54,7 @@ case class SimpleOgcLayer(
   source: RasterSource,
   style: Option[OgcStyle],
   resampleMethod: ResampleMethod
-) extends OgcLayer
+) extends OgcLayer with RasterOgcLayer
 
 case class MapAlgebraOgcLayer(
   name: String,

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
@@ -1,5 +1,7 @@
 package geotrellis.server.ogc
 
+import jp.ne.opt.chronoscala.Imports._
+
 import java.time.ZonedDateTime
 
 /**
@@ -30,10 +32,25 @@ final case class OgcTimeInterval(start: ZonedDateTime,
       case _ => start.toInstant.toString
     }
   }
+
+  /**
+   * Merge two OgcTimeInterval instances
+   *
+   * @note This method destroys the interval. If you need to retain interval when combining
+   *       instances, perform this operation yourself.
+   * @param other
+   * @return
+   */
+  def combine(other: OgcTimeInterval) = {
+    val times = List(Some(start), end, Some(other.start), other.end).flatten
+    OgcTimeInterval(times.min, Some(times.max), None)
+  }
 }
 
 object OgcTimeInterval {
   def apply(timePeriod: ZonedDateTime): OgcTimeInterval = OgcTimeInterval(timePeriod, None, None)
+
+  def apply(timeString: String): OgcTimeInterval = fromString(timeString)
 
   def fromString(timeString: String): OgcTimeInterval = {
     val timeParts = timeString.split("/")

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -30,10 +30,19 @@ case class WcsModel(
     val filteredSources = sources.find(p.toQuery)
     logger.debug(s"Filtering sources: ${sources.store.length} -> ${filteredSources.length}")
     filteredSources.map {
-        case SimpleSource(name, title, source, _, styles, resampleMethod) =>
+        case SimpleSource(name, title, source, _, _, resampleMethod) =>
           SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod)
-        case MapAlgebraSource(name, title, sources, algebra, _, styles, resampleMethod) =>
-          val simpleLayers = sources.mapValues { rs => SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod) }
+        case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, _) =>
+          val source = if (p.temporalSequence.nonEmpty) {
+            gts.sourceForTime(p.temporalSequence.head)
+          } else {
+            gts.source
+          }
+          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod)
+        case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod) =>
+          val simpleLayers = sources.mapValues { rs =>
+            SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod)
+          }
           MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra, None, resampleMethod)
       }
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -131,12 +131,13 @@ object CapabilitiesView {
           EX_GeographicBoundingBox(llExtent.xmin, llExtent.xmax, llExtent.ymin, llExtent.ymax).some
         },
         BoundingBox         = Nil,
-        Dimension           = source.time match {
-          case Some(time) => Seq(Dimension(
-            OgcTimeInterval(time).toString,
+        Dimension           = source.timeInterval match {
+          case Some(interval) => Seq(Dimension(
+            interval.toString,
             Map(
               "@name" -> DataRecord("time"),
-              "@units" -> DataRecord("ISO8601")
+              "@units" -> DataRecord("ISO8601"),
+              "@default" -> DataRecord(interval.start.toString)
             )
           ))
           case None => Nil
@@ -178,7 +179,7 @@ object CapabilitiesView {
       },
       // TODO: bounding box for global layer
       BoundingBox         = Nil,
-      Dimension           = model.temporalRange match {
+      Dimension           = model.timeInterval match {
         case Some(interval) => Seq(Dimension(
           interval.toString,
           Map(

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -40,6 +40,7 @@ case class WmtsModel(
     for {
       crs    <- getMatrixCrs(p.tileMatrixSet).toList
       layout <- getMatrixLayoutDefinition(p.tileMatrixSet, p.tileMatrix).toList
+      // TODO: Refactor so that we can return multiple layers
       source <- sources.find(p.toQuery)
     } yield {
       val style: Option[OgcStyle] = source.styles.find(_.name == p.style)


### PR DESCRIPTION
## Overview

**My comments are in the git log for the HEAD commit on this branch. Additional context there.**

This PR addresses the major concerns raised in #219:
- [x] Can we revert to upstream GeoTrellisRasterSource? Yes -- we'll need to add the time related changes to upstream though
- [x] Can we minimize the number of RasterSource instantiations we do for GeoTrellis layers? Yes -- Now 2. One when we build the conf on server start, one every time we go to read from the layer in a GetMap or equivalent call
- [x] Can we defer RasterSource instantiation until just before we're ready to read data? Yes, see bullet above

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

It should still be possible to load and view both application.conf. It should still be possible to load application-spacetimekey.conf and view the GetCapabilities or equivalent views for WMS/WCS manually. GetMap or equivalent views will still time out due to excessive reads of the underlying test rastersource.

Closes #219
