### PR TITLE
Use Eclipse repositories instead of locationtech

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
     "osgeo" at "https://download.osgeo.org/webdav/geotools/",
-    "locationtech-releases" at "https://repo.locationtech.org/content/groups/releases",
-    "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots"
+    "eclipse-releases" at "https://repo.eclipse.org/content/groups/releases",
+    "eclipse-snapshots" at "https://repo.eclipse.org/content/groups/snapshots"
   ),
   addCompilerPlugin(kindProjector cross CrossVersion.full),
   addCompilerPlugin(macrosParadise cross CrossVersion.full),


### PR DESCRIPTION
Locationtech repos would go away soon, this PR switches us to eclipse repos.

Closes https://github.com/geotrellis/geotrellis-server/issues/239
