### PR TITLE
WMS extended capabilities and WCS user defined parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Configurable ResampleMethod in source definitions [#229](https://github.com/geotrellis/geotrellis-server/issues/229)
 - Enable TargetCell parameter for focal operations [#212](https://github.com/geotrellis/geotrellis-server/issues/212)
+- WMS Extended capabilities and operations [#235](https://github.com/geotrellis/geotrellis-server/issues/235)
+- WCS GetCapabilities user defined parameters [#237](https://github.com/geotrellis/geotrellis-server/issues/237)
 
 ### Changed
  

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTimeInterval.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc
 
 import jp.ne.opt.chronoscala.Imports._

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/LegendModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/LegendModel.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc.style
 
 case class LegendModel(

--- a/ogc/src/main/scala/geotrellis/server/ogc/style/OnlineResourceModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/style/OnlineResourceModel.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc.style
 
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/utils/Implicits.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/utils/Implicits.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.utils
+
+import scalaxb.DataRecord
+
+import scala.xml.Elem
+
+trait Implicits {
+  implicit class DataRecordMethods[A](dataRecord: DataRecord[A]) {
+    def toXML: Elem = ScalaxbUtils.toXML(dataRecord)
+  }
+}
+
+object Implicits extends Implicits

--- a/ogc/src/main/scala/geotrellis/server/ogc/utils/ScalaxbUtils.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/utils/ScalaxbUtils.scala
@@ -18,18 +18,19 @@ package geotrellis.server.ogc.utils
 
 import scalaxb.DataRecord
 
+import scala.xml.XML
 import scala.xml.Elem
 
 object ScalaxbUtils {
-  def toXML[A](record: DataRecord[A], skipValue: Boolean = false): Elem = {
-    if (!skipValue) (record.namespace, record.key, record.value) match {
-      case (None, Some(k), _) => scala.xml.XML.loadString(s"<$k>${record.value}</$k>")
-      case (Some(n), Some(k), _) => scala.xml.XML.loadString(s"<$n:$k>${record.value}</$n:$k>")
-      case _ => scala.xml.XML.loadString(s"<${record.value}/>")
+  def toXML[A](record: DataRecord[A], dropValue: Boolean = false): Elem = {
+    if (!dropValue) (record.namespace, record.key, record.value) match {
+      case (None, Some(k), _)    => XML.loadString(s"<$k>${record.value}</$k>")
+      case (Some(n), Some(k), _) => XML.loadString(s"<$n:$k>${record.value}</$n:$k>")
+      case _                     => XML.loadString(s"<${record.value}/>")
     } else (record.namespace, record.key, record.value) match {
-      case (None, Some(k), _) => scala.xml.XML.loadString(s"<$k/>")
-      case (Some(n), Some(k), _) => scala.xml.XML.loadString(s"<$n:$k/>")
-      case _ => throw new IllegalArgumentException(s"The passed record $record should contain namespace or key.")
+      case (None, Some(k), _)    => XML.loadString(s"<$k/>")
+      case (Some(n), Some(k), _) => XML.loadString(s"<$n:$k/>")
+      case _                     => throw new IllegalArgumentException(s"The passed record $record should contain namespace or key.")
     }
   }
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/utils/ScalaxbUtils.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/utils/ScalaxbUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.utils
+
+import scalaxb.DataRecord
+
+import scala.xml.Elem
+
+object ScalaxbUtils {
+  def toXML[A](record: DataRecord[A], skipValue: Boolean = false): Elem = {
+    if (!skipValue) (record.namespace, record.key, record.value) match {
+      case (None, Some(k), _) => scala.xml.XML.loadString(s"<$k>${record.value}</$k>")
+      case (Some(n), Some(k), _) => scala.xml.XML.loadString(s"<$n:$k>${record.value}</$n:$k>")
+      case _ => scala.xml.XML.loadString(s"<${record.value}/>")
+    } else (record.namespace, record.key, record.value) match {
+      case (None, Some(k), _) => scala.xml.XML.loadString(s"<$k/>")
+      case (Some(n), Some(k), _) => scala.xml.XML.loadString(s"<$n:$k/>")
+      case _ => throw new IllegalArgumentException(s"The passed record $record should contain namespace or key.")
+    }
+  }
+}

--- a/ogc/src/main/scala/geotrellis/server/ogc/utils/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/utils/package.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc
+
+package object utils extends utils.Implicits

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CapabilitiesView.scala
@@ -161,6 +161,36 @@ class CapabilitiesView(
           ),
           DefaultValue = ValueType("nearest neighbor").some,
           attributes = Map("@name" -> DataRecord("InterpolationType"))
+        ) :: DomainType(
+          possibleValuesOption1 = OwsDataRecord(
+            AllowedValues(
+              OwsDataRecord(
+                ValueType("all")
+              ) :: OwsDataRecord(
+                ValueType("data")
+              ) :: OwsDataRecord(
+                ValueType("nodata")
+              ) :: Nil)
+          ),
+          DefaultValue = ValueType("all").some,
+          attributes = Map(
+            "@name" -> DataRecord("target")
+          )
+        ) :: DomainType(
+          possibleValuesOption1 = OwsDataRecord(AnyValue()),
+          attributes = Map(
+            "@name" -> DataRecord("zFactor")
+          )
+        ) :: DomainType(
+          possibleValuesOption1 = OwsDataRecord(AnyValue()),
+          attributes = Map(
+            "@name" -> DataRecord("azimuth")
+          )
+        ) :: DomainType(
+          possibleValuesOption1 = OwsDataRecord(AnyValue()),
+          attributes = Map(
+            "@name" -> DataRecord("altitude")
+          )
         ) :: Nil,
         attributes = Map("@name" -> DataRecord("GetCoverage"))
       )

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -18,6 +18,8 @@ package geotrellis.server.ogc.wms
 
 import geotrellis.server.ogc._
 import geotrellis.server.ogc.style._
+import geotrellis.server.ogc.utils._
+
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster.CellSize
 import geotrellis.vector.Extent
@@ -25,11 +27,10 @@ import cats.syntax.option._
 import opengis.wms._
 import opengis._
 import scalaxb._
+
 import java.net.URL
 
-import geotrellis.server.ogc.utils.ScalaxbUtils
-
-import scala.xml.{Elem, TopScope}
+import scala.xml.Elem
 
 /**
   *
@@ -66,10 +67,10 @@ class CapabilitiesView(
       val extendedCapabilities = {
         val targetCells = DataRecord(
           None, "target".some,
-          ScalaxbUtils.toXML(DataRecord("all")) ++
-          ScalaxbUtils.toXML(DataRecord("data")) ++
-          ScalaxbUtils.toXML(DataRecord("nodata")) ++
-          ScalaxbUtils.toXML(DataRecord(None, "default".some, "all"))
+          DataRecord("all").toXML ++
+          DataRecord("data").toXML ++
+          DataRecord("nodata").toXML ++
+          DataRecord(None, "default".some, "all").toXML
         )
 
         val focalHillshade: Elem = ExtendedElement(

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -18,18 +18,18 @@ package geotrellis.server.ogc.wms
 
 import geotrellis.server.ogc._
 import geotrellis.server.ogc.style._
-
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster.CellSize
 import geotrellis.vector.Extent
-
 import cats.syntax.option._
 import opengis.wms._
 import opengis._
 import scalaxb._
-
 import java.net.URL
-import scala.xml.Elem
+
+import geotrellis.server.ogc.utils.ScalaxbUtils
+
+import scala.xml.{Elem, TopScope}
 
 /**
   *
@@ -62,10 +62,38 @@ class CapabilitiesView(
         ) :: Nil
       )
 
+
+      val extendedCapabilities = {
+        val targetCells = DataRecord(
+          None, "target".some,
+          ScalaxbUtils.toXML(DataRecord("all")) ++
+          ScalaxbUtils.toXML(DataRecord("data")) ++
+          ScalaxbUtils.toXML(DataRecord("nodata")) ++
+          ScalaxbUtils.toXML(DataRecord(None, "default".some, "all"))
+        )
+
+        val focalHillshade: Elem = ExtendedElement(
+          "FocalHillshade",
+          DataRecord("zFactor"),
+          DataRecord("azimuth"),
+          DataRecord("altitude"),
+          targetCells
+        )
+
+        val focalSlope: Elem = ExtendedElement(
+          "FocalSlope",
+          DataRecord("zFactor"),
+          targetCells
+        )
+
+        ExtendedCapabilities(focalHillshade, focalSlope)
+      }
+
       Capability(
         Request = Request(GetCapabilities = getCapabilities, GetMap = getMap, GetFeatureInfo = None),
         Exception = Exception("XML" :: "INIMAGE" :: "BLANK" :: Nil),
-        Layer = modelAsLayer(model.parentLayerMeta, model).some
+        Layer = modelAsLayer(model.parentLayerMeta, model).some,
+        _ExtendedCapabilities = extendedCapabilities
       )
     }
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
@@ -17,13 +17,14 @@
 package geotrellis.server.ogc
 
 import geotrellis.server.ogc.style._
-
+import geotrellis.server.ogc.utils.ScalaxbUtils
+import cats.syntax.option._
 import opengis._
 import opengis.wms._
 import scalaxb._
-
 import java.net.URI
-import scala.xml.NamespaceBinding
+
+import scala.xml.{Elem, NamespaceBinding, NodeSeq}
 
 package object wms {
   val wmsScope: NamespaceBinding = scalaxb.toScope(
@@ -70,4 +71,10 @@ package object wms {
         "@{http://www.w3.org/1999/xlink}actuate" -> that.actuate.map(v => DataRecord(xlink.ActuateType.fromString(v, scope = scalaxb.toScope(Some("xlink") -> "http://www.w3.org/1999/xlink"))))
       ).collect { case (k, Some(v)) => k -> v })
   }
+
+  def ExtendedElement[A](key: String, records: DataRecord[A]*): Elem =
+    ScalaxbUtils.toXML(DataRecord(None, key.some, records.map(ScalaxbUtils.toXML(_)).foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)))
+
+  def ExtendedCapabilities[A](records: Elem*): List[DataRecord[Elem]] =
+    DataRecord(ScalaxbUtils.toXML(DataRecord(None, "ExtendedCapabilities".some, ScalaxbUtils.toXML(DataRecord(None, "GetMap".some, records.foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)))))) :: Nil
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
@@ -17,11 +17,12 @@
 package geotrellis.server.ogc
 
 import geotrellis.server.ogc.style._
-import geotrellis.server.ogc.utils.ScalaxbUtils
+import geotrellis.server.ogc.utils._
 import cats.syntax.option._
 import opengis._
 import opengis.wms._
 import scalaxb._
+
 import java.net.URI
 
 import scala.xml.{Elem, NamespaceBinding, NodeSeq}
@@ -73,8 +74,8 @@ package object wms {
   }
 
   def ExtendedElement[A](key: String, records: DataRecord[A]*): Elem =
-    ScalaxbUtils.toXML(DataRecord(None, key.some, records.map(ScalaxbUtils.toXML(_)).foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)))
+    DataRecord(None, key.some, records.map(_.toXML).foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)).toXML
 
   def ExtendedCapabilities[A](records: Elem*): List[DataRecord[Elem]] =
-    DataRecord(ScalaxbUtils.toXML(DataRecord(None, "ExtendedCapabilities".some, ScalaxbUtils.toXML(DataRecord(None, "GetMap".some, records.foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)))))) :: Nil
+    DataRecord(DataRecord(None, "ExtendedCapabilities".some, DataRecord(None, "GetMap".some, records.foldLeft(NodeSeq.Empty)((acc, e) => acc ++ e)).toXML).toXML) :: Nil
 }

--- a/ogc/src/test/scala/geotrellis/server/ogc/InterpolatedColorMapSpec.scala
+++ b/ogc/src/test/scala/geotrellis/server/ogc/InterpolatedColorMapSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc
 
 import geotrellis.server.ogc.style._

--- a/ogc/src/test/scala/geotrellis/server/ogc/OgcStyleSpec.scala
+++ b/ogc/src/test/scala/geotrellis/server/ogc/OgcStyleSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.server.ogc
 
 import geotrellis.server.ogc.style._


### PR DESCRIPTION
## Overview

This PR Adds WMS extended Capabilies:

```xml
<ExtendedCapabilities>
    <GetMap>
        <FocalHillshade>
            <zFactor/>
            <azimuth/>
            <altitude/>
            <target>
                <all/>
                <data/>
                <nodata/>
                <default>all</default>
            </target>
        </FocalHillshade>
        <FocalSlope>
            <zFactor/>
            <target>
                <all/>
                <data/>
                <nodata/>
                <default>all</default>
            </target>
        </FocalSlope>
    </GetMap>
</ExtendedCapabilities>
```

And WCS Extra parameters (it looks like there is no way to specify some description for these parameters): 

```xml
<ows:Operation name="GetCapabilities">
...
    <ows:Parameter name="target">
        <ows:AllowedValues>
            <ows:Value>all</ows:Value>
            <ows:Value>data</ows:Value>
            <ows:Value>nodata</ows:Value>
        </ows:AllowedValues>
        <ows:DefaultValue>all</ows:DefaultValue>
    </ows:Parameter>
    <ows:Parameter name="zFactor">
        <ows:AnyValue/>
    </ows:Parameter>
    <ows:Parameter name="azimuth">
        <ows:AnyValue/>
    </ows:Parameter>
    <ows:Parameter name="altitude">
        <ows:AnyValue/>
    </ows:Parameter>
...
</ows:Operation>
```

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

Closes #235
Closes #237
