### PR TITLE
Add ColorRampStyle.clampWithColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable TargetCell parameter for focal operations [#212](https://github.com/geotrellis/geotrellis-server/issues/212)
 - WMS Extended capabilities and operations [#235](https://github.com/geotrellis/geotrellis-server/issues/235)
 - WCS GetCapabilities user defined parameters [#237](https://github.com/geotrellis/geotrellis-server/issues/237)
+- ColorRampStyle.clampWithColor option to render colors outside the requested render range as colors in the ramp instead of as transparent pixels [#220](https://github.com/geotrellis/geotrellis-server/issues/220)
 
 ### Changed
  

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -260,14 +260,26 @@ layers = {
         name = "us-ned"
         title = "US NED"
         source = "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
+        default-style = "elevation-ramp"
         styles = [
           {
             type = "colorrampconf"
-            name = "Elevation Ramp"
+            name = "elevation-ramp"
             title = "Elevation Ramp"
             colors = ${color-ramps.elevation}
             stops = 90
-          }
+          },
+          {
+            type = "colorrampconf"
+            name = "elevation-ramp-clamped"
+            title = "Elevation Ramp: 1000 - 3000m"
+            colors = ${color-ramps.red-to-blue}
+            stops = 90
+            min-render = 1000
+            max-render = 3000
+            clamp-with-color = true
+          },
+
         ]
     }
     addition-house-income = {

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/StyleConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/StyleConf.scala
@@ -36,10 +36,11 @@ final case class ColorRampConf(
   stops: Option[Int],
   minRender: Option[Double],
   maxRender: Option[Double],
+  clampWithColor: Boolean = false,
   legends: List[LegendModel] = Nil
 ) extends StyleConf {
   def toStyle: OgcStyle =
-    ColorRampStyle(name, title, colors, stops, minRender, maxRender, legends)
+    ColorRampStyle(name, title, colors, stops, minRender, maxRender, clampWithColor, legends)
 }
 
 /** Styling in which both a color scheme and the data-to-color mapping is known */


### PR DESCRIPTION
## Overview

Adds option `clamp-with-color` to `colorrampstyle` that renders values outside the requested min/max render range with the min/max color values from the ramp rather than transparent pixels. 

Default is false to maintain backwards
compatibility for existing configurations

I'm taking naming suggestions for a better name for the new config option. A succinct descriptive name remains elusive.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

With the following change applied:
```diff
diff --git a/ogc-example/src/main/resources/application.conf b/ogc-example/src/main/resources/application.conf
index 50209b1..a2170d1 100644
--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -260,13 +260,17 @@ layers = {
         name = "us-ned"
         title = "US NED"
         source = "gt+s3://azavea-datahub/catalog?layer=us-ned-tms-epsg3857&zoom=14&band_count=1"
+        default-style = "Elevation Ramp"
         styles = [
           {
             type = "colorrampconf"
             name = "Elevation Ramp"
             title = "Elevation Ramp"
-            colors = ${color-ramps.elevation}
+            colors = ${color-ramps.red-to-blue}
             stops = 90
+            min-render = 1000
+            max-render = 3000
+            clamp-with-color = true
           }
         ]
     }
```

This layer will render like this for `clamp-with-color = true`:
![Screen Shot 2020-03-30 at 2 50 28 PM](https://user-images.githubusercontent.com/1818302/77951941-e02f1980-7298-11ea-96ca-a685b3a12027.png)

And like this for `clamp-with-color = false` (the default, should match the rendering on `develop`):
![Screen Shot 2020-03-30 at 2 51 12 PM](https://user-images.githubusercontent.com/1818302/77951955-e3c2a080-7298-11ea-8530-2ff7ea41e14a.png)


## Testing Instructions

Apply the diff shown in Demo to your application.conf and load the layer. Ensure that it looks the same on develop and with `clamp-with-color = false` and that colors are rendered instead of transparent pixels with the new option enabled.

Closes #220 
