### PR TITLE
Expose overview strategy into the layers configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WMS GetMap support of extended parameters [#236](https://github.com/geotrellis/geotrellis-server/issues/236)
 - WCS GetCoverage support of extended parameters [#238](https://github.com/geotrellis/geotrellis-server/issues/238)
 - ColorRampStyle.clampWithColor option to render colors outside the requested render range as colors in the ramp instead of as transparent pixels [#220](https://github.com/geotrellis/geotrellis-server/issues/220)
+- Expose overview strategy into the layers configuration [#252](https://github.com/geotrellis/geotrellis-server/pull/252)
 
 ### Changed
  
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Addressed GeoTrellisRasterSourceLegacy issues and minimized number of RasterSource instances constructed for GeoTrellis Layers [#219](https://github.com/geotrellis/geotrellis-server/issues/219)
+- Some source resolutions are sometimes skipped leading to reading too much tiles [#215](https://github.com/geotrellis/geotrellis-server/issues/215)
 
 ## [4.1.0] - 2020-03-03
 

--- a/core/src/test/scala/geotrellis/server/ResourceTile.scala
+++ b/core/src/test/scala/geotrellis/server/ResourceTile.scala
@@ -19,18 +19,19 @@ package geotrellis.server
 import geotrellis.server.vlm._
 import geotrellis.raster._
 import geotrellis.raster.geotiff._
-import geotrellis.raster.io.geotiff.AutoHigherResolution
-import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.raster.io.geotiff.OverviewStrategy
+import geotrellis.raster.resample._
 import geotrellis.vector.Extent
 
 import cats.effect._
 import cats.data.{NonEmptyList => NEL}
 
-case class ResourceTile(name: String, resampleMethod: ResampleMethod = NearestNeighbor) {
-  def uri = {
-    val f = getClass.getResource(s"/$name").getFile
-    s"file://$f"
-  }
+case class ResourceTile(
+  name: String,
+  resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
+  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT
+) {
+  def uri: String = s"file://${getClass.getResource(s"/$name").getFile}"
 }
 
 object ResourceTile extends RasterSourceUtils {
@@ -40,7 +41,7 @@ object ResourceTile extends RasterSourceUtils {
     def extentReification(self: ResourceTile)(implicit contextShift: ContextShift[IO]): (Extent, CellSize) => IO[ProjectedRaster[MultibandTile]] =
       (extent: Extent, cs: CellSize) => {
         val rs = getRasterSource(self.uri.toString)
-        rs.resample(TargetRegion(new GridExtent[Long](extent, cs)), self.resampleMethod, AutoHigherResolution)
+        rs.resample(TargetRegion(new GridExtent[Long](extent, cs)), self.resampleMethod, self.overviewStrategy)
           .read(extent)
           .map { raster => ProjectedRaster(raster, rs.crs) }
           .toIO { new Exception(s"No tile avail for RasterExtent: ${RasterExtent(extent, cs)}") }

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -349,6 +349,7 @@ layers = {
       name = "us-ned-hillshade"
       title = "US NED Hillshade"
       resample-method = "bilinear"
+      overview-strategy = "auto-0"
       algebra = {
         "args" : [
           {

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -107,7 +107,7 @@ object Main extends CommandApp(
             simpleSources = conf
               .layers
               .values
-              .collect { case rsc@RasterSourceConf(_, _, _, _, _, _) => rsc.toLayer }
+              .collect { case rsc@RasterSourceConf(_, _, _, _, _, _, _) => rsc.toLayer }
               .toList
             _ <- Stream.eval(IO(logOptState(
               conf.wms,

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -30,9 +30,9 @@ sealed trait OgcServiceConf {
   def layerDefinitions: List[OgcSourceConf]
   def layerSources(rasterOgcSources: List[RasterOgcSource]): OgcSourceRepository = {
     val rasterLayers: List[RasterOgcSource] =
-      layerDefinitions.collect { case rsc @ RasterSourceConf(_, _, _, _, _, _) => rsc.toLayer }
+      layerDefinitions.collect { case rsc @ RasterSourceConf(_, _, _, _, _, _, _) => rsc.toLayer }
     val mapAlgebraLayers: List[MapAlgebraSource] =
-      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _) => masc.model(rasterOgcSources) }
+      layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _, _) => masc.model(rasterOgcSources) }
     ogc.OgcSourceRepository(rasterLayers ++ mapAlgebraLayers)
   }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -16,11 +16,12 @@
 
 package geotrellis.server.ogc.conf
 
-import com.azavea.maml.ast._
-import geotrellis.raster.{RasterSource, ResampleMethod}
-import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.raster.RasterSource
+import geotrellis.raster.io.geotiff.OverviewStrategy
+import geotrellis.raster.resample._
 import geotrellis.server.ogc._
 import geotrellis.store.GeoTrellisPath
+import com.azavea.maml.ast._
 
 // This sumtype corresponds to the in-config representation of a source
 sealed trait OgcSourceConf {
@@ -35,15 +36,16 @@ case class RasterSourceConf(
   source: String,
   defaultStyle: Option[String],
   styles: List[StyleConf],
-  resampleMethod: ResampleMethod = NearestNeighbor
+  resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
+  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT
 ) extends OgcSourceConf {
   def toLayer: RasterOgcSource = {
     GeoTrellisPath.parseOption(source) match {
       case Some(_) => GeoTrellisOgcSource(
-        name, title, source, defaultStyle, styles.map(_.toStyle), resampleMethod
+        name, title, source, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy
       )
       case None => SimpleSource(
-        name, title, RasterSource(source), defaultStyle, styles.map(_.toStyle), resampleMethod
+        name, title, RasterSource(source), defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy
       )
     }
   }
@@ -55,7 +57,8 @@ case class MapAlgebraSourceConf(
   algebra: Expression,
   defaultStyle: Option[String],
   styles: List[StyleConf],
-  resampleMethod: ResampleMethod = NearestNeighbor
+  resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
+  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT
 ) extends OgcSourceConf {
   private def listParams(expr: Expression): List[String] = {
     def eval(subExpr: Expression): List[String] = subExpr match {
@@ -81,6 +84,6 @@ case class MapAlgebraSourceConf(
       }
       name -> layerSrc.source
     }
-    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod)
+    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy)
   }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wms/WmsView.scala
@@ -94,16 +94,16 @@ class WmsView(wmsModel: WmsModel, serviceUrl: URL) {
         val re = RasterExtent(wmsReq.boundingBox, wmsReq.width, wmsReq.height)
         wmsModel.getLayer(wmsReq).map { layer =>
           val evalExtent = layer match {
-            case sl @ SimpleOgcLayer(_, _, _, _, _, _) =>
+            case sl @ SimpleOgcLayer(_, _, _, _, _, _, _) =>
               LayerExtent.identity(sl)
-            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _) =>
+            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _, _) =>
               LayerExtent(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO])
           }
 
           val evalHisto = layer match {
-            case sl @ SimpleOgcLayer(_, _, _, _, _, _) =>
+            case sl @ SimpleOgcLayer(_, _, _, _, _, _, _) =>
               LayerHistogram.identity(sl, 512)
-            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _) =>
+            case MapAlgebraOgcLayer(_, _, _, parameters, expr, _, _, _) =>
               LayerHistogram(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO], 512)
           }
 

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -60,16 +60,16 @@ class WmtsView(wmtsModel: WmtsModel, serviceUrl: URL) {
           val layerName = wmtsReq.layer
           wmtsModel.getLayer(wmtsReq).map { layer =>
             val evalWmts = layer match {
-              case sl @ SimpleTiledOgcLayer(_, _, _, _, _, _, _) =>
+              case sl @ SimpleTiledOgcLayer(_, _, _, _, _, _, _, _) =>
                 LayerTms.identity(sl)
-              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _) =>
+              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _, _) =>
                 LayerTms(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO])
             }
 
             val evalHisto = layer match {
-              case sl@SimpleTiledOgcLayer(_, _, _, _, _, _, _) =>
+              case sl@SimpleTiledOgcLayer(_, _, _, _, _, _, _, _) =>
                 LayerHistogram.identity(sl, 512)
-              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _) =>
+              case MapAlgebraTiledOgcLayer(_, _, _, _, parameters, expr, _, _, _) =>
                 LayerHistogram(IO.pure(expr), IO.pure(parameters), ConcurrentInterpreter.DEFAULT[IO], 512)
             }
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
@@ -60,7 +60,7 @@ object CoverageView {
     val nativeCrs = source.nativeCrs.head
     val re = source.nativeRE
     val llre = source match {
-      case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod) =>
+      case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod, _) =>
         rss.values.map { rs =>
           ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng, Options.DEFAULT.copy(resampleMethod))
         }.reduce({ (re1, re2) =>
@@ -94,7 +94,7 @@ object CoverageView {
      * https://portal.ogc.org/files/07-067r5
      */
     val temporalDomain: Option[TimeSequenceType] = source match {
-      case gtl @ GeoTrellisOgcSource(_, _, _, _, _, _, _) =>
+      case gtl @ GeoTrellisOgcSource(_, _, _, _, _, _, _, _) =>
         if (gtl.source.isTemporal) {
           val records = gtl.source.times.map { t =>
             GmlDataRecord(TimePositionType(t.toInstant.toString))

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
@@ -60,8 +60,8 @@ class GetCoverage(wcsModel: WcsModel) {
           .getLayers(params)
           .headOption
           .map {
-            case so @ SimpleOgcLayer(_, _, _, _, _, _) => LayerExtent.identity(so)
-            case MapAlgebraOgcLayer(_, _, _, simpleLayers, algebra, _, _) =>
+            case so @ SimpleOgcLayer(_, _, _, _, _, _, _) => LayerExtent.identity(so)
+            case MapAlgebraOgcLayer(_, _, _, simpleLayers, algebra, _, _, _) =>
               LayerExtent(IO.pure(algebra), IO.pure(simpleLayers), ConcurrentInterpreter.DEFAULT)
           }
           .traverse { eval =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -35,21 +35,21 @@ case class WcsModel(
     val filteredSources = sources.find(p.toQuery)
     logger.debug(s"Filtering sources: ${sources.store.length} -> ${filteredSources.length}")
     filteredSources.map {
-        case SimpleSource(name, title, source, _, _, resampleMethod) =>
-          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod)
-        case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, _) =>
+        case SimpleSource(name, title, source, _, _, resampleMethod, overviewStrategy) =>
+          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod, overviewStrategy)
+        case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, overviewStrategy, _) =>
           val source = if (p.temporalSequence.nonEmpty) {
             gts.sourceForTime(p.temporalSequence.head)
           } else {
             gts.source
           }
-          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod)
-        case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod) =>
+          SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod, overviewStrategy)
+        case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod, overviewStrategy) =>
           val simpleLayers = sources.mapValues { rs =>
-            SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod)
+            SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod, overviewStrategy)
           }
           val extendedParameters = extendedParametersBinding.flatMap(_.apply(p.params))
-          MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra.bindExtendedParameters(extendedParameters), None, resampleMethod)
+          MapAlgebraOgcLayer(name, title, p.crs, simpleLayers, algebra.bindExtendedParameters(extendedParameters), None, resampleMethod, overviewStrategy)
       }
   }
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -49,17 +49,17 @@ case class WmsModel(
             source.styles.find(_.name == name)
           }
           source match {
-            case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod) =>
+            case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod, overviewStrategy) =>
               val simpleLayers = rasterSources.mapValues { rs =>
-                SimpleOgcLayer(name, title, supportedCrs, rs, style, resampleMethod)
+                SimpleOgcLayer(name, title, supportedCrs, rs, style, resampleMethod, overviewStrategy)
               }
               val extendedParameters = extendedParametersBinding.flatMap(_.apply(p.params))
-              MapAlgebraOgcLayer(name, title, supportedCrs, simpleLayers, algebra.bindExtendedParameters(extendedParameters), style, resampleMethod)
-            case SimpleSource(name, title, rasterSource, _, _, resampleMethod) =>
-              SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod)
-            case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, _) =>
+              MapAlgebraOgcLayer(name, title, supportedCrs, simpleLayers, algebra.bindExtendedParameters(extendedParameters), style, resampleMethod, overviewStrategy)
+            case SimpleSource(name, title, rasterSource, _, _, resampleMethod, overviewStrategy) =>
+              SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod, overviewStrategy)
+            case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, overviewStrategy, _) =>
               val rasterSource = p.time.fold(gts.source)(gts.sourceForTime)
-              SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod)
+              SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod, overviewStrategy)
           }
         }
       }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -45,13 +45,13 @@ case class WmtsModel(
     } yield {
       val style: Option[OgcStyle] = source.styles.find(_.name == p.style)
       source match {
-        case MapAlgebraSource(name, title, rasterSources, algebra, _, styles, resampleMethod) =>
+        case MapAlgebraSource(name, title, rasterSources, algebra, _, styles, resampleMethod, overviewStrategy) =>
           val simpleLayers = rasterSources.mapValues { rs =>
-            SimpleTiledOgcLayer(name, title, crs, layout, rs, style, resampleMethod)
+            SimpleTiledOgcLayer(name, title, crs, layout, rs, style, resampleMethod, overviewStrategy)
           }
-          MapAlgebraTiledOgcLayer(name, title, crs, layout, simpleLayers, algebra, style, resampleMethod)
-        case SimpleSource(name, title, rasterSource, _, styles, resampleMethod) =>
-          SimpleTiledOgcLayer(name, title, crs, layout, rasterSource, style, resampleMethod)
+          MapAlgebraTiledOgcLayer(name, title, crs, layout, simpleLayers, algebra, style, resampleMethod, overviewStrategy)
+        case SimpleSource(name, title, rasterSource, _, styles, resampleMethod, overviewStrategy) =>
+          SimpleTiledOgcLayer(name, title, crs, layout, rasterSource, style, resampleMethod, overviewStrategy)
       }
     }
   }


### PR DESCRIPTION
## Overview

This PR allows to specify the overview strategy to select on the resample / reproject operations.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Notes

These overview strategies behave in the same (or in a similar) way [GDALWarp overview strategies](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-ovr) behave.

The following overview strategies support is added:

```
"auto-higher-resolution" # a default behavior 
         # tries to pick up a resolution that matches best
"base".  # always uses the layer with the best resolution for the resampling operations
"auto-n" # n is int, where n >= 0 # behaves like gdal, 
         # so if the reoslution is a bit off, it would pick up the less resolute overview for sampleing
"level-n" # n is int, where n >= 0 # n is a number of an overview we'd like to use 
          # for all layer sampling operations
```

Add the overview startegy definition into the ogcExamples project `application.conf`:

```conf
us-ned-hillshade = {
  type = "mapalgebrasourceconf"
  name = "us-ned-hillshade"
  title = "US NED Hillshade"
  resample-method = "bilinear"
  overview-strategy = "auto-0"
...
```

The default behaviour is 

Addresses #215
