### PR TITLE
Bump GT version up

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val commonSettings = Seq(
     Resolver.bintrayRepo("azavea", "geotrellis"),
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
-    "osgeo" at "https://download.osgeo.org/webdav/geotools/",
+    "osgeo-snapshots" at "https://repo.osgeo.org/repository/snapshot/",
+    "osgeo-releases" at "https://repo.osgeo.org/repository/release/",
     "eclipse-releases" at "https://repo.eclipse.org/content/groups/releases",
     "eclipse-snapshots" at "https://repo.eclipse.org/content/groups/snapshots"
   ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   val circeVer = "0.11.1"
   val dispatchVer = "0.11.3"
-  val gtVer = "3.3.0"
+  val gtVer = "3.3.1-SNAPSHOT"
   val jaxbApiVer = "2.3.1"
   val refinedVer = "0.9.9"
   val shapelessVer = "2.3.3"


### PR DESCRIPTION
## Overview

This PR updates GT version up

Addresses https://github.com/geotrellis/geotrellis-server/issues/248
