### PR TITLE
Remove sbt-coursier plugin

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")


### PR DESCRIPTION
We updated to sbt 1.3 which bundles coursier
by default. According to coursier docs its
no longer necessary to keep the manually
installed plugin:

https://get-coursier.io/docs/sbt-coursier.html#sbt-13x

Keeping the plugin was causing this transient
error for some developers when attempting to start SBT:

```
[info] Resolved geotrellis-server-build dependencies
[error] coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[error]     org.scala-sbt:global-plugins;sbtVersion=1.0;scalaVersion=2.12:0.0:
```
