### PR TITLE
Receive GPG key while publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ aliases:
     - run:
         name: "Import signing key"
         command: |
+          gpg --keyserver keyserver.ubuntu.com \
+            --recv-keys 0x13E9AA1D8153E95E && \
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
           gpg --batch \
             --import signing_key.asc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
-                - feature/cek/receive-gpg-key
 
 jobs:
   "openjdk8-scala2.11.12":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,7 @@ aliases:
           gpg --keyserver keyserver.ubuntu.com \
             --recv-keys 0x13E9AA1D8153E95E && \
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
-          gpg --batch \
-            --import signing_key.asc
+          gpg --import signing_key.asc
     - run:
         name: Executing cipublish
         command: ./scripts/cipublish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
+                - feature/cek/receive-gpg-key
 
 jobs:
   "openjdk8-scala2.11.12":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ aliases:
         command: |
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
           gpg --batch \
-            --passphrase "${GPG_PASSPHRASE}" \
             --import signing_key.asc
     - run:
         name: Executing cipublish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `layers.layer-name.sources` field in application.conf is renamed to `source` and now supports a single RasterSource URI string. See `ogc-example/src/main/resources/application.conf` for examples. 
 - `type = "simplesourceconf"` should be changed to `type = "rastersourceconf"` in application.conf
 - Remove GeoTrellisRasterSourceLegacy [#197](https://github.com/geotrellis/geotrellis-server/issues/197)
+- Receive GPG key while publishing artifacts [#271](https://github.com/geotrellis/geotrellis-server/pull/271)
 
 ### Fixed
 


### PR DESCRIPTION
## Overview

This retrieves an up-to-date copy of the Geotrellis public GPG key during the `cipublish` build stage.

We've pushed a new signature to extend the expiration date on the public key that we've uploaded to public keyservers. The CircleCI build will now retrieve the latest copy of the public key, allowing us to renew the key in the future using the same procedure.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

- Verify that updated and valid Geotrellis GPG key is retrieved and verified during `cipublish`.
  - Verified by @rbreslow during pairing session.

Connects azavea/operations#446