### PR TITLE
Fix ExtentRefication, wcs and wms default behavior when time is not specified for temporal layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose overview strategy into the layers configuration [#252](https://github.com/geotrellis/geotrellis-server/pull/252)
 - RGB styling configuration [#249](https://github.com/geotrellis/geotrellis-server/issues/249)
 - Add STAC Support [#263](https://github.com/geotrellis/geotrellis-server/pull/263)
+- Fix ExtentRefication, wcs and wms default behavior when time is not specified for temporal layers [#278](https://github.com/geotrellis/geotrellis-server/pull/278)
 
 ### Changed
  

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
@@ -80,7 +80,10 @@ object SimpleOgcLayer {
         val raster: Raster[MultibandTile] = self.source
           .reprojectToRegion(self.crs, targetGrid.toRasterExtent, self.resampleMethod, self.overviewStrategy)
           .read(extent)
-          .getOrElse(throw new Exception(s"Unable to retrieve layer $self at extent $extent $cs"))
+          .getOrElse {
+            logger.trace(s"Unable to retrieve layer $self at extent $extent $cs")
+            Raster(MultibandTile(ArrayTile.empty(self.source.cellType, 10, 10)), extent)
+          }
         logger.trace(s"Successfully retrieved layer $self at extent $extent with f $cs ${targetGrid.cols}x${targetGrid.rows}")
 
         ProjectedRaster(raster, self.crs)

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
@@ -84,7 +84,7 @@ class GetCoverage(wcsModel: WcsModel) {
              // STAC search will return an empty list, however QGIS may expect a test pixel to
              // return the actual tile
              // TODO: handle it in a proper way, how to get information about the bands amount?
-             val tile = ArrayTile(Array(0, 0), 1, 1)
+             val tile = ArrayTile.empty(IntCellType, 1, 1)
              GeoTiff(
                Raster(
                  MultibandTile(tile, tile, tile),

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -37,11 +37,10 @@ case class WcsModel(
         case SimpleSource(name, title, source, _, _, resampleMethod, overviewStrategy) =>
           SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod, overviewStrategy)
         case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, overviewStrategy, _) =>
-          val source = if (p.temporalSequence.nonEmpty) {
-            gts.sourceForTime(p.temporalSequence.head)
-          } else {
-            gts.source
-          }
+          val source =
+            if (p.temporalSequence.nonEmpty) gts.sourceForTime(p.temporalSequence.head)
+            else if (p.temporalSequence.isEmpty && gts.source.isTemporal) gts.sourceForTime(gts.source.times.head)
+            else gts.source
           SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod, overviewStrategy)
         case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod, overviewStrategy) =>
           val simpleLayers = sources.mapValues { rs =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -58,8 +58,12 @@ case class WmsModel(
             case SimpleSource(name, title, rasterSource, _, _, resampleMethod, overviewStrategy) =>
               SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod, overviewStrategy)
             case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, overviewStrategy, _) =>
-              val rasterSource = p.time.fold(gts.source)(gts.sourceForTime)
-              SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod, overviewStrategy)
+              val source = p.time match {
+                case Some(t) => gts.sourceForTime(t)
+                case _ if gts.source.isTemporal => gts.sourceForTime(gts.source.times.head)
+                case _ => gts.source
+              }
+              SimpleOgcLayer(name, title, supportedCrs, source, style, resampleMethod, overviewStrategy)
           }
         }
       }


### PR DESCRIPTION
## Overview

This PR fixed behavior with all the default layers we have in application.conf and makes the mavailable through QGIS.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

