### PR TITLE
Only use default time when param is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Addressed GeoTrellisRasterSourceLegacy issues and minimized number of RasterSource instances constructed for GeoTrellis Layers [#219](https://github.com/geotrellis/geotrellis-server/issues/219)
 - Some source resolutions are sometimes skipped leading to reading too much tiles [#215](https://github.com/geotrellis/geotrellis-server/issues/215)
 - LayerHistogram should select the CellSize large enough to compute the histogram [#261](https://github.com/geotrellis/geotrellis-server/pull/261)
+- Removed WMS GetMap fallback to default time when an incorrect TIME query parameter has been provided [#260](https://github.com/geotrellis/geotrellis-server/pull/280)
 
 ## [4.1.0] - 2020-03-03
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -59,8 +59,8 @@ case class WmsModel(
               SimpleOgcLayer(name, title, supportedCrs, rasterSource, style, resampleMethod, overviewStrategy)
             case gts @ GeoTrellisOgcSource(name, title, _, _, _, resampleMethod, overviewStrategy, _) =>
               val source = p.time match {
-                case Some(t) => gts.sourceForTime(t)
-                case _ if gts.source.isTemporal => gts.sourceForTime(gts.source.times.head)
+                case Some(t) if gts.source.times.contains(t.start) => gts.sourceForTime(t)
+                case None if gts.source.isTemporal => gts.sourceForTime(gts.source.times.head)
                 case _ => gts.source
               }
               SimpleOgcLayer(name, title, supportedCrs, source, style, resampleMethod, overviewStrategy)


### PR DESCRIPTION
## Overview

Default times for temporal layers should only be used when no `TIME` query parameter is provided. This PR causes bad temporal queries to fail rather than fall back on the default.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

Should succeed (date provided):
http://localhost:8888/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=43.81618476019971808,-79.40248489379884234,43.94325769600655462,-79.15603855282134305&CRS=EPSG:4326&WIDTH=850&HEIGHT=439&LAYERS=markham&STYLES=&FORMAT=image/png&DPI=72&MAP_RESOLUTION=72&FORMAT_OPTIONS=dpi:72&TRANSPARENT=TRUE&TIME=1960-01-01T12:00Z
Should fail (date provided):
http://localhost:8888/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=43.81618476019971808,-79.40248489379884234,43.94325769600655462,-79.15603855282134305&CRS=EPSG:4326&WIDTH=850&HEIGHT=439&LAYERS=markham&STYLES=&FORMAT=image/png&DPI=72&MAP_RESOLUTION=72&FORMAT_OPTIONS=dpi:72&TRANSPARENT=TRUE&TIME=1960-01-02T12:00Z
Default case:
http://localhost:8888/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=43.81618476019971808,-79.40248489379884234,43.94325769600655462,-79.15603855282134305&CRS=EPSG:4326&WIDTH=850&HEIGHT=439&LAYERS=markham&STYLES=&FORMAT=image/png&DPI=72&MAP_RESOLUTION=72&FORMAT_OPTIONS=dpi:72&TRANSPARENT=TRUE

Closes #260
