### PR TITLE
Fix bad wms time parsing

### DIFF
--- a/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
@@ -106,5 +106,5 @@ case class ParamMap(params: Map[String, Seq[String]]) {
     }
 
   def validatedOgcTime(field: String): ValidatedNel[ParamError, OgcTime] =
-    validatedOgcTimeSequence(field).map(_.head)
+    validatedOgcTimeSequence(field).map(_.headOption.getOrElse(OgcTimeEmpty))
 }


### PR DESCRIPTION
## Overview

This PR fixes an incorrect time parsing which caused runtime exceptions trying to access a layer without specifiying time.
