### PR TITLE
Expose time into MapAlgebraSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose STAC temporal metadata [#279](https://github.com/geotrellis/geotrellis-server/pull/279)
 - Support for Time lists in WMS GetCapabilities [#259](https://github.com/geotrellis/geotrellis-server/issues/259)
 - Default attribute should not be used to serve response inside Time extent [#260](https://github.com/geotrellis/geotrellis-server/issues/260)
+- Enabling Time Dimension for mapalgebrasourceconf on Temporal Layers [#262](https://github.com/geotrellis/geotrellis-server/issues/262)
 
 ### Changed
  

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -79,8 +79,9 @@ case class MapAlgebraSourceConf(
         throw new Exception(
           s"MAML Layer expected but was unable to find the simple layer '$name', make sure all required layers are in the server configuration and are correctly spelled there and in all provided MAML")
       }
-      name -> layerSrc.source
+      (layerSrc.timeMetadataKey, name -> layerSrc.source)
     }
-    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy)
+    val timeMetadataKey = sourceList.flatMap(_._1).headOption
+    MapAlgebraSource(name, title, sourceList.map(_._2).toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy, timeMetadataKey)
   }
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -42,7 +42,7 @@ case class WcsModel(
               case _ => gts.source
             }
           SimpleOgcLayer(name, title, p.crs, source, None, resampleMethod, overviewStrategy)
-        case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod, overviewStrategy) =>
+        case MapAlgebraSource(name, title, sources, algebra, _, _, resampleMethod, overviewStrategy, _) =>
           val simpleLayers = sources.mapValues { rs =>
             SimpleOgcLayer(name, title, p.crs, rs, None, resampleMethod, overviewStrategy)
           }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -130,7 +130,7 @@ object CapabilitiesView {
         },
         EX_GeographicBoundingBox = {
           val llre = source match {
-            case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod, _) =>
+            case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod, _, _) =>
               rss.values.map { rs =>
                 ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng, Options.DEFAULT.copy(resampleMethod))
               }.reduce({ (re1, re2) =>
@@ -205,7 +205,7 @@ object CapabilitiesView {
       EX_GeographicBoundingBox = {
         val llExtents = model.sources.store.map { source =>
           val llre = source match {
-            case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod, _) =>
+            case MapAlgebraSource(_, _, rss, _, _, _, resampleMethod, _, _) =>
               rss.values.map { rs =>
                 ReprojectRasterExtent(rs.gridExtent, rs.crs, LatLng, Options.DEFAULT.copy(resampleMethod))
               }.reduce({ (re1, re2) =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -51,7 +51,7 @@ case class WmsModel(
             source.styles.find(_.name == name)
           }
           source match {
-            case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod, overviewStrategy) =>
+            case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod, overviewStrategy, _) =>
               val simpleLayers = rasterSources.mapValues { rs =>
                 SimpleOgcLayer(name, title, supportedCrs, rs, style, resampleMethod, overviewStrategy)
               }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -44,7 +44,7 @@ case class WmtsModel(
     } yield {
       val style: Option[OgcStyle] = source.styles.find(_.name == p.style)
       source match {
-        case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod, overviewStrategy) =>
+        case MapAlgebraSource(name, title, rasterSources, algebra, _, _, resampleMethod, overviewStrategy, _) =>
           val simpleLayers = rasterSources.mapValues { rs =>
             SimpleTiledOgcLayer(name, title, crs, layout, rs, style, resampleMethod, overviewStrategy)
           }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -110,18 +110,19 @@ case class MapAlgebraSourceConf(
         throw new Exception(
           s"MAML Layer expected but was unable to find the simple layer '$name', make sure all required layers are in the server configuration and are correctly spelled there and in all provided MAML")
       }
-      name -> layerSrc.source
+      (layerSrc.timeMetadataKey, name -> layerSrc.source)
     }
-    MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy)
+    val timeMetadataKey = sourceList.flatMap(_._1).headOption
+    MapAlgebraSource(name, title, sourceList.map(_._2).toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy, timeMetadataKey)
   }
 
   def modelOpt(possibleSources: List[RasterOgcSource]): Option[MapAlgebraSource] = {
     val layerNames = listParams(algebra)
     val sourceList = layerNames.flatMap { name =>
-      possibleSources.find(_.name == name).map { layerSrc => name -> layerSrc.source }
+      possibleSources.find(_.name == name).map { layerSrc => (layerSrc.timeMetadataKey, name -> layerSrc.source) }
     }
-
-    if(sourceList.nonEmpty) Some(MapAlgebraSource(name, title, sourceList.toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy))
+    val timeMetadataKey = sourceList.flatMap(_._1).headOption
+    if(sourceList.nonEmpty) MapAlgebraSource(name, title, sourceList.map(_._2).toMap, algebra, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy, timeMetadataKey).some
     else None
   }
 }


### PR DESCRIPTION
## Overview

This PR enables temporal support for MapAlgebraSources. The only requirement here is that all RasterSources should have temporal information stored under the same metadata key.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

#### WMS:
![image](https://user-images.githubusercontent.com/4929546/85046543-93076900-b15e-11ea-934c-f47b994f54d8.png)

#### WCS:
![image](https://user-images.githubusercontent.com/4929546/85046491-87b43d80-b15e-11ea-922a-00b6c9625229.png)

Closes #262
