### PR TITLE
Fix STAC API TemporalExtent JSON representation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pc.stdout.log
 .bloop
 .metals
 metals.sbt
+.history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- Logging into STAC API Client [#293](https://github.com/geotrellis/geotrellis-server/pull/293)
+
 ### Changed
 - *BREAKING* Typeclasses no longer bind the effect type to IO [#284](https://github.com/geotrellis/geotrellis-server/pull/284)
 - Optimize MapAlgebraStacOgcRepositories [#291](https://github.com/geotrellis/geotrellis-server/pull/291)
@@ -33,14 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabling Time Dimension for mapalgebrasourceconf on Temporal Layers [#262](https://github.com/geotrellis/geotrellis-server/issues/262)
 
 ### Changed
- 
 - The `layers.layer-name.sources` field in application.conf is renamed to `source` and now supports a single RasterSource URI string. See `ogc-example/src/main/resources/application.conf` for examples. 
 - `type = "simplesourceconf"` should be changed to `type = "rastersourceconf"` in application.conf
 - Remove GeoTrellisRasterSourceLegacy [#197](https://github.com/geotrellis/geotrellis-server/issues/197)
 - Receive GPG key while publishing artifacts [#271](https://github.com/geotrellis/geotrellis-server/pull/271)
 
 ### Fixed
-
 - Addressed GeoTrellisRasterSourceLegacy issues and minimized number of RasterSource instances constructed for GeoTrellis Layers [#219](https://github.com/geotrellis/geotrellis-server/issues/219)
 - Some source resolutions are sometimes skipped leading to reading too much tiles [#215](https://github.com/geotrellis/geotrellis-server/issues/215)
 - LayerHistogram should select the CellSize large enough to compute the histogram [#261](https://github.com/geotrellis/geotrellis-server/pull/261)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING* Typeclasses no longer bind the effect type to IO [#284](https://github.com/geotrellis/geotrellis-server/pull/284)
 - Optimize MapAlgebraStacOgcRepositories [#291](https://github.com/geotrellis/geotrellis-server/pull/291)
 
+## Fixed
+- Fix STAC API TemporalExtent JSON representation [#293](https://github.com/geotrellis/geotrellis-server/pull/293)
+
 ## [4.2.0] - 2020-06-23
 
 ### Added

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -27,6 +27,7 @@ import geotrellis.server.ogc.wmts.GeotrellisTileMatrixSet
 import geotrellis.server.ogc.stac._
 import geotrellis.store.query.{Repository, RepositoryM}
 import org.http4s.client.Client
+import io.chrisdavenport.log4cats.Logger
 
 /**
   * Each service has its own unique configuration requirements (see the below instances)
@@ -44,7 +45,7 @@ sealed trait OgcServiceConf {
     ogc.OgcSourceRepository(rasterLayers ++ mapAlgebraLayers)
   }
 
-  def layerSources[F[_]: Sync: SemigroupK](rasterOgcSources: List[RasterOgcSource], client: Client[F]): RepositoryM[F, List, OgcSource] = {
+  def layerSources[F[_]: Sync: SemigroupK: Logger](rasterOgcSources: List[RasterOgcSource], client: Client[F]): RepositoryM[F, List, OgcSource] = {
     val stacLayers: List[StacSourceConf]                 = layerDefinitions.collect { case ssc @ StacSourceConf(_, _, _, _, _, _, _, _, _, _, _) => ssc }
     val mapAlgebraConfLayers: List[MapAlgebraSourceConf] = layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _, _) => masc }
 

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
@@ -27,6 +27,7 @@ import cats.syntax.semigroup._
 import cats.instances.list._
 import higherkindness.droste.scheme
 import org.http4s.client.Client
+import io.chrisdavenport.log4cats.Logger
 
 case class MapAlgebraStacOgcRepository[F[_]: Sync](
   mapAlgebraSourceConf: MapAlgebraSourceConf,
@@ -49,7 +50,7 @@ case class MapAlgebraStacOgcRepository[F[_]: Sync](
       .widen
 }
 
-case class MapAlgebraStacOgcRepositories[F[_]: Sync](
+case class MapAlgebraStacOgcRepositories[F[_]: Sync: Logger](
   mapAlgebraConfLayers: List[MapAlgebraSourceConf],
   stacLayers: List[StacSourceConf],
   client: Client[F]

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
@@ -35,8 +35,9 @@ import geotrellis.stac.raster.StacAssetRasterSource
 import higherkindness.droste.{scheme, Algebra}
 import org.http4s.Uri
 import org.http4s.client.Client
+import io.chrisdavenport.log4cats.Logger
 
-case class StacOgcRepository[F[_]: Sync](
+case class StacOgcRepository[F[_]: Sync: Logger](
   stacSourceConf: StacSourceConf,
   client: StacClient[F]
 ) extends RepositoryM[F, List, OgcSource] {
@@ -76,7 +77,7 @@ case class StacOgcRepository[F[_]: Sync](
   }
 }
 
-case class StacOgcRepositories[F[_]: Sync](
+case class StacOgcRepositories[F[_]: Sync: Logger](
   stacLayers: List[StacSourceConf],
   client: Client[F]
 ) extends RepositoryM[F, List, OgcSource] {

--- a/stac-example/src/main/scala/geotrellis/stac/api/Http4sStacClient.scala
+++ b/stac-example/src/main/scala/geotrellis/stac/api/Http4sStacClient.scala
@@ -24,53 +24,61 @@ import io.circe.syntax._
 import org.http4s.circe._
 import cats.syntax.functor._
 import cats.syntax.either._
+import cats.syntax.apply._
 import cats.effect.{ConcurrentEffect, Resource, Sync}
 import eu.timepit.refined.types.string.NonEmptyString
 import org.http4s.client.blaze.BlazeClientBuilder
+import io.chrisdavenport.log4cats.Logger
 
 import scala.concurrent.ExecutionContext
 
-case class Http4sStacClient[F[_]: Sync](
+case class Http4sStacClient[F[_]: Sync: Logger](
   client: Client[F],
   baseUri: Uri
 ) extends StacClient[F] {
-  private def postRequest: Request[F] = Request[F]().withMethod(POST)
-  private def getRequest: Request[F]  = Request[F]().withMethod(GET)
+  private lazy val logger = Logger[F]
+  private def postRequest = Request[F]().withMethod(POST)
+  private def getRequest  = Request[F]().withMethod(GET)
 
   def search(filter: SearchFilters = SearchFilters()): F[List[StacItem]] =
+    logger.trace(s"search: ${filter.asJson.spaces4}") *>
     client
       .expect(postRequest.withUri(baseUri.withPath("/search")).withEntity(filter.asJson.noSpaces))
       .map(_.hcursor.downField("features").as[List[StacItem]].bimap(_ => Nil, identity).merge)
 
   def collections: F[List[StacCollection]] =
+    logger.trace("collections") *>
     client
       .expect(getRequest.withUri(baseUri.withPath("/collections")))
       .map(_.hcursor.downField("collections").as[List[StacCollection]].bimap(_ => Nil, identity).merge)
 
   def collection(collectionId: NonEmptyString): F[Option[StacCollection]] =
+    logger.trace(s"collection: $collectionId") *>
     client
       .expect(getRequest.withUri(baseUri.withPath(s"/collections/$collectionId")))
       .map(_.as[Option[StacCollection]].bimap(_ => None, identity).merge)
 
   def items(collectionId: NonEmptyString): F[List[StacItem]] =
+    logger.trace(s"items: $collectionId") *>
     client
       .expect(getRequest.withUri(baseUri.withPath(s"/collections/$collectionId/items")))
       .map(_.hcursor.downField("features").as[List[StacItem]].bimap(_ => Nil, identity).merge)
 
   def item(collectionId: NonEmptyString, itemId: NonEmptyString): F[Option[StacItem]] =
+    logger.trace(s"items: $collectionId, $itemId") *>
     client
       .expect(getRequest.withUri(baseUri.withPath(s"/collections/$collectionId/items/$itemId")))
       .map(_.as[Option[StacItem]].bimap(_ => None, identity).merge)
 }
 
 object Http4sStacClient {
-  def apply[F[_]: ConcurrentEffect](baseUri: Uri)(implicit ec: ExecutionContext): F[Http4sStacClient[F]] = {
+  def apply[F[_]: ConcurrentEffect: Logger](baseUri: Uri)(implicit ec: ExecutionContext): F[Http4sStacClient[F]] = {
     BlazeClientBuilder[F](ec).resource.use { client =>
       ConcurrentEffect[F].delay(Http4sStacClient[F](client, baseUri))
     }
   }
 
-  def resource[F[_]: ConcurrentEffect](baseUri: Uri)(implicit ec: ExecutionContext): Resource[F, Http4sStacClient[F]] = {
+  def resource[F[_]: ConcurrentEffect: Logger](baseUri: Uri)(implicit ec: ExecutionContext): Resource[F, Http4sStacClient[F]] = {
     BlazeClientBuilder[F](ec).resource.map { client =>
       Http4sStacClient[F](client, baseUri)
     }

--- a/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
+++ b/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
@@ -29,8 +29,12 @@ import cats.Semigroup
 import cats.syntax.option._
 import cats.syntax.either._
 import cats.syntax.semigroup._
+import cats.syntax.apply._
 import cats.instances.option._
+import cats.instances.either._
 import cats.instances.list._
+
+import java.time.Instant
 
 case class SearchFilters(
   bbox: Option[Bbox] = None,
@@ -44,6 +48,53 @@ case class SearchFilters(
 )
 
 object SearchFilters {
+  // TemporalExtent STAC API compatible serialization
+  private def stringToInstant(s: String): Either[Throwable, Instant] =
+    Either.catchNonFatal(Instant.parse(s))
+
+  private def temporalExtentToString(te: TemporalExtent): String =
+    te.value match {
+      case Some(start) :: Some(end) :: _ if start != end => s"${start.toString}/${end.toString}"
+      case Some(start) :: Some(end) :: _ if start == end => s"${start.toString}"
+      case Some(start) :: None :: _                      => s"${start.toString}/.."
+      case None :: Some(end) :: _                        => s"../${end.toString}"
+    }
+
+  private def temporalExtentFromString(str: String): Either[String, TemporalExtent] = {
+    str.split("/").toList match {
+      case ".." :: endString :: _        =>
+        val parsedEnd = stringToInstant(endString)
+        parsedEnd match {
+          case Left(_)             => s"Could not decode instant: $str".asLeft
+          case Right(end: Instant) => TemporalExtent(None, end).asRight
+        }
+      case startString :: ".." :: _      =>
+        val parsedStart = stringToInstant(startString)
+        parsedStart match {
+          case Left(_)               => s"Could not decode instant: $str".asLeft
+          case Right(start: Instant) => TemporalExtent(start, None).asRight
+        }
+      case startString :: endString :: _ =>
+        val parsedStart = stringToInstant(startString)
+        val parsedEnd   = stringToInstant(endString)
+        (parsedStart, parsedEnd).tupled match {
+          case Left(_)                               => s"Could not decode instant: $str".asLeft
+          case Right((start: Instant, end: Instant)) => TemporalExtent(start, end).asRight
+        }
+      case _                             =>
+        Either.catchNonFatal(Instant.parse(str)) match {
+          case Left(_)           => s"Could not decode instant: $str".asLeft
+          case Right(t: Instant) => TemporalExtent(t, t).asRight
+        }
+    }
+  }
+
+  implicit val encoderTemporalExtent: Encoder[TemporalExtent] =
+    Encoder.encodeString.contramap[TemporalExtent](temporalExtentToString)
+
+  implicit val decoderTemporalExtent: Decoder[TemporalExtent] =
+    Decoder.decodeString.emap(temporalExtentFromString)
+
   object IntersectionSemigroup {
     implicit val bboxIntersectionSemigroup: Semigroup[Bbox] = { (left, right) =>
       val Extent(xmin, ymin, xmax, ymax) =

--- a/stac-example/src/test/scala/geotrellis/stac/IOSpec.scala
+++ b/stac-example/src/test/scala/geotrellis/stac/IOSpec.scala
@@ -19,11 +19,14 @@ package geotrellis.stac
 import cats.effect.{ContextShift, IO, Timer}
 import geotrellis.store.util.BlockingThreadPool
 import org.scalatest._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
 trait IOSpec extends AsyncFunSpec with Assertions with Matchers {
   override implicit val executionContext      = BlockingThreadPool.executionContext
   implicit val contextShift: ContextShift[IO] = IO.contextShift(executionContext)
   implicit val timer: Timer[IO]               = IO.timer(executionContext)
+  implicit val logger: Logger[IO]             = Slf4jLogger.getLogger[IO]
 
   private val itWord = new ItWord
 

--- a/stac-example/src/test/scala/geotrellis/stac/api/Http4sStacClientSpec.scala
+++ b/stac-example/src/test/scala/geotrellis/stac/api/Http4sStacClientSpec.scala
@@ -30,12 +30,13 @@ import cats.syntax.either._
 import geotrellis.proj4.CRS
 import geotrellis.stac.raster.StacRepository
 import geotrellis.vector.{Extent, ProjectedExtent}
+import io.chrisdavenport.log4cats.{Logger => Logger4Cats}
 
 import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
 
 class Http4sStacClientSpec extends IOSpec {
-  def withClient[F[_]: ConcurrentEffect](implicit ec: ExecutionContext) =
+  def withClient[F[_]: ConcurrentEffect: Logger4Cats](implicit ec: ExecutionContext) =
     new {
       def apply[T](f: StacClient[F] => F[T]): F[T] = {
         // Http4sStacClient[F](Uri.fromString("http://localhost:9090/"))


### PR DESCRIPTION
## Overview

This PR fixes STAC API TemporalExtent JSON representation and makes it compatible with STAC API and adds tracing level logging into the STAC API Client.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

