### PR TITLE
Fix STAC Temporal support

### DIFF
--- a/core/src/main/scala/geotrellis/store/query/package.scala
+++ b/core/src/main/scala/geotrellis/store/query/package.scala
@@ -35,7 +35,9 @@ package object query {
     def or(right: Query): Query           = QueryF.or(self, right)
     def and(right: Query): Query          = QueryF.and(self, right)
     def isTemporal: Boolean               = QueryF.isTemporal(self)
+    def nonTemporal: Boolean              = !isTemporal
     def isUniversal: Boolean              = QueryF.isUniversal(self)
+    def nonUniversal: Boolean             = !isUniversal
     def overrideName(name: String): Query = QueryF.overrideName(self, name)
   }
 

--- a/core/src/main/scala/geotrellis/store/query/package.scala
+++ b/core/src/main/scala/geotrellis/store/query/package.scala
@@ -32,8 +32,11 @@ package object query {
   implicit val queryDecoder: Decoder[Query] = Decoder.decodeJson.map(QueryF.fromJson)
 
   implicit class QueryOps(val self: Query) extends AnyVal {
-    def or(right: Query): Query  = QueryF.or(self, right)
-    def and(right: Query): Query = QueryF.and(self, right)
+    def or(right: Query): Query           = QueryF.or(self, right)
+    def and(right: Query): Query          = QueryF.and(self, right)
+    def isTemporal: Boolean               = QueryF.isTemporal(self)
+    def isUniversal: Boolean              = QueryF.isUniversal(self)
+    def overrideName(name: String): Query = QueryF.overrideName(self, name)
   }
 
   def or(left: Query, right: Query): Query                       = QueryF.or(left, right)

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
@@ -39,6 +39,13 @@ object OgcTime {
     case (_: OgcTimeEmpty.type, r: OgcTimeInterval)  => r
     case (l, _)                                      => l
   }
+
+  def strictTimeMatch(time: OgcTime, dt: ZonedDateTime): Boolean =
+    time match {
+      case OgcTimePositions(list)       => list.head == dt
+      case OgcTimeInterval(start, _, _) => start == dt
+      case OgcTimeEmpty                 => true
+    }
 }
 
 case object OgcTimeEmpty extends OgcTime {

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
@@ -16,11 +16,11 @@
 
 package geotrellis.server.ogc
 
-import jp.ne.opt.chronoscala.Imports._
 import cats.data.NonEmptyList
 import cats.{Monoid, Order, Semigroup}
 import cats.syntax.option._
 import cats.syntax.semigroup._
+import jp.ne.opt.chronoscala.Imports._
 
 import java.time.ZonedDateTime
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcTime.scala
@@ -18,7 +18,7 @@ package geotrellis.server.ogc
 
 import jp.ne.opt.chronoscala.Imports._
 import cats.data.NonEmptyList
-import cats.{Order, Semigroup}
+import cats.{Monoid, Order, Semigroup}
 import cats.syntax.option._
 import cats.syntax.semigroup._
 
@@ -30,14 +30,18 @@ sealed trait OgcTime {
 }
 
 object OgcTime {
-  implicit val ogcTimeSemigroup: Semigroup[OgcTime] = {
-    case (l: OgcTimePositions, r: OgcTimePositions)  => l |+| r
-    case (l: OgcTimeInterval, r: OgcTimeInterval)    => l |+| r
-    case (l: OgcTimePositions, _: OgcTimeEmpty.type) => l
-    case (l: OgcTimeInterval, _: OgcTimeEmpty.type)  => l
-    case (_: OgcTimeEmpty.type, r: OgcTimePositions) => r
-    case (_: OgcTimeEmpty.type, r: OgcTimeInterval)  => r
-    case (l, _)                                      => l
+  implicit val ogcTimeMonoid: Monoid[OgcTime] = new Monoid[OgcTime] {
+    def empty: OgcTime                           = OgcTimeEmpty
+    def combine(l: OgcTime, r: OgcTime): OgcTime =
+      (l, r) match {
+        case (l: OgcTimePositions, r: OgcTimePositions)  => l |+| r
+        case (l: OgcTimeInterval, r: OgcTimeInterval)    => l |+| r
+        case (l: OgcTimePositions, _: OgcTimeEmpty.type) => l
+        case (l: OgcTimeInterval, _: OgcTimeEmpty.type)  => l
+        case (_: OgcTimeEmpty.type, r: OgcTimePositions) => r
+        case (_: OgcTimeEmpty.type, r: OgcTimeInterval)  => r
+        case (l, _)                                      => l
+      }
   }
 
   def strictTimeMatch(time: OgcTime, dt: ZonedDateTime): Boolean =
@@ -57,9 +61,11 @@ case object OgcTimeEmpty extends OgcTime {
 
 /** Represents the TimePosition used in TimeSequence requests */
 final case class OgcTimePositions(list: NonEmptyList[ZonedDateTime]) extends OgcTime {
+  import OgcTimePositions._
+
   def toOgcTimeInterval: OgcTimeInterval = {
-    val l = list.toList.sorted
-    OgcTimeInterval(l.min, l.max, None)
+    val times = list.sorted
+    OgcTimeInterval(times.head, times.last, None)
   }
   override def toString: String = list.toList.map(_.toInstant.toString).mkString(", ")
 }
@@ -68,7 +74,7 @@ object OgcTimePositions {
   implicit val timeOrder: Order[ZonedDateTime] = Order.fromOrdering
 
   implicit val ogcTimePositionsSemigroup: Semigroup[OgcTimePositions] = { (l, r) =>
-    OgcTimePositions((l.list ::: r.list).distinct)
+    OgcTimePositions((l.list ::: r.list).distinct.sorted)
   }
 
   def apply(timePeriod: ZonedDateTime): OgcTimePositions             = OgcTimePositions(NonEmptyList(timePeriod, Nil))
@@ -114,8 +120,8 @@ object OgcTimeInterval {
     *  instances, perform this operation yourself.
     */
   implicit val ogcTimeIntervalSemigroup: Semigroup[OgcTimeInterval] = { (l, r) =>
-    val times = List(l.start, l.end, r.start, r.end)
-    OgcTimeInterval(times.min, times.max, None)
+    val times = List(l.start, l.end, r.start, r.end).sorted
+    OgcTimeInterval(times.head, times.last, None)
   }
 
   def apply(timePeriod: ZonedDateTime): OgcTimeInterval = OgcTimeInterval(timePeriod, timePeriod, None)

--- a/stac-example/src/main/resources/application.conf
+++ b/stac-example/src/main/resources/application.conf
@@ -227,6 +227,7 @@ layers = {
         asset = "B4"
         asset-limit = 1000
         source = "http://localhost:9090/"
+        default-time = true
         default-style = "red-to-blue"
         styles = [
             {
@@ -248,6 +249,7 @@ layers = {
         asset-limit = 1000
         source = "http://localhost:9090/"
         default-style = "red-to-blue"
+        default-time = true
         styles = [
             {
                 name = "red-to-blue"
@@ -268,6 +270,7 @@ layers = {
         asset-limit = 1000
         source = "http://localhost:9090/"
         default-style = "red-to-blue"
+        default-time = true
         styles = [
             {
                 name = "red-to-blue"

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -46,7 +46,7 @@ sealed trait OgcServiceConf {
   }
 
   def layerSources[F[_]: Sync: SemigroupK: Logger](rasterOgcSources: List[RasterOgcSource], client: Client[F]): RepositoryM[F, List, OgcSource] = {
-    val stacLayers: List[StacSourceConf]                 = layerDefinitions.collect { case ssc @ StacSourceConf(_, _, _, _, _, _, _, _, _, _, _) => ssc }
+    val stacLayers: List[StacSourceConf]                 = layerDefinitions.collect { case ssc @ StacSourceConf(_, _, _, _, _, _, _, _, _, _, _, _, _) => ssc }
     val mapAlgebraConfLayers: List[MapAlgebraSourceConf] = layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _, _) => masc }
 
     layerSources(rasterOgcSources).toF[F] |+|

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -47,9 +47,10 @@ case class StacSourceConf(
   styles: List[StyleConf],
   commonCrs: CRS = WebMercator,
   resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
-  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT
+  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT,
+  defaultTime: Boolean = false,
+  datetimeField: String = "datetime"
 ) extends OgcSourceConf {
-  private val datetimeField                   = "datetime"
   def toLayer(rs: RasterSource): SimpleSource =
     SimpleSource(name, title, rs, defaultStyle, styles.map(_.toStyle), resampleMethod, overviewStrategy, datetimeField.some)
 }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
@@ -25,7 +25,6 @@ import cats.effect.Sync
 import cats.syntax.functor._
 import cats.syntax.semigroup._
 import cats.instances.list._
-import higherkindness.droste.scheme
 import org.http4s.client.Client
 import io.chrisdavenport.log4cats.Logger
 

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/MapAlgebraStacOgcRepositories.scala
@@ -38,13 +38,10 @@ case class MapAlgebraStacOgcRepository[F[_]: Sync](
 
   def store: F[List[OgcSource]] = find(query.all)
 
-  /** Replace the OGC layer name with its STAC Layer name */
-  private def queryWithName(query: Query)(name: String): Query =
-    scheme.ana(QueryF.coalgebraWithName(name)).apply(query)
-
   def find(query: Query): F[List[OgcSource]] =
+    /** Replace the OGC layer name with its STAC Layer name */
     repository
-      .find(names.map(queryWithName(query)).fold(nothing)(_ or _))
+      .find(names.map(query.overrideName).fold(nothing)(_ or _))
       .map(_.collect { case ss: SimpleSource => ss })
       .map(mapAlgebraSourceConf.modelOpt(_).toList)
       .widen

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
@@ -74,7 +74,7 @@ case class StacOgcRepository[F[_]: Sync: Logger](
                 * All non temporal items would be included into the result.
                 * Otherwise, only items that match the first time position would be returned.
                 */
-              val sources            = if (stacSourceConf.defaultTime && !query.isTemporal && !query.isUniversal) {
+              val sources            = if (stacSourceConf.defaultTime && query.nonTemporal && query.nonUniversal) {
                 val datetimeField = stacSourceConf.datetimeField.some
                 rasterSources.map(_.time(datetimeField)).reduce(_ |+| _) match {
                   case OgcTimePositions(list)       =>

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
@@ -65,10 +65,10 @@ case class StacOgcRepository[F[_]: Sync: Logger](
             case head :: Nil => head.some
             case head :: _   =>
               /**
-                * By default STAC API returns all temporal items even though the time was not specified.
+                * By default STAC API returns all temporal items even though the time is not specified.
                 * If defaultTime configuration is set to true and the query is not temporal and not universal
-                * (meaning that it bounds by temporal or spatial extent),
-                * we can try to select the first time position of the temporal layer.
+                * (meaning that it is bounded by temporal or spatial extent),
+                * we can select the first time position of the temporal layer in this case.
                 *
                 * If the layer is not temporal, no extra filtering would be applied.
                 * All non temporal items would be included into the result.

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
@@ -37,8 +37,6 @@ import higherkindness.droste.{scheme, Algebra}
 import org.http4s.Uri
 import org.http4s.client.Client
 import io.chrisdavenport.log4cats.Logger
-import jp.ne.opt.chronoscala.Imports._
-import org.checkerframework.checker.units.qual.s
 
 case class StacOgcRepository[F[_]: Sync: Logger](
   stacSourceConf: StacSourceConf,

--- a/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
+++ b/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
@@ -208,7 +208,7 @@ object SearchFilters {
       case All()              => SearchFilters().some
       case WithName(name)     => SearchFilters(query = Map("layer:ids" -> Map("superset" -> List(name).asJson).asJson).asJsonObject).some
       case WithNames(names)   => SearchFilters(query = Map("layer:ids" -> Map("superset" -> names.asJson).asJson).asJsonObject).some
-      case At(t, _)           => SearchFilters(datetime = TemporalExtent(t.toInstant, None).some).some
+      case At(t, _)           => SearchFilters(datetime = TemporalExtent(t.toInstant, t.toInstant).some).some
       case Between(t1, t2, _) => SearchFilters(datetime = TemporalExtent(t1.toInstant, t2.toInstant).some).some
       case Intersects(e)      => SearchFilters(intersects = e.reproject(LatLng).extent.toPolygon.some).some
       case Covers(e)          => SearchFilters(bbox = e.reproject(LatLng).extent.toTwoDimBbox.some).some


### PR DESCRIPTION
## Overview

1. This PR fixes Query => SearchFilters conversion
2. Add a `defaultTime` STAC configuration to change the default behavior of stac catalogs: instead of pulling down all the sources it can select only the default time position instead of merging everything into a single layer

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

