### PR TITLE
Update STAC4s up to 0.0.11 with STAC 1.0.0-beta.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *BREAKING* Typeclasses no longer bind the effect type to IO [#284](https://github.com/geotrellis/geotrellis-server/pull/284)
 - Optimize MapAlgebraStacOgcRepositories [#291](https://github.com/geotrellis/geotrellis-server/pull/291)
+- Update STAC4s up to 0.0.11 with STAC 1.0.0-beta.1 support [#295](https://github.com/geotrellis/geotrellis-server/pull/295)
 
 ## Fixed
 - Fix STAC API TemporalExtent JSON representation [#293](https://github.com/geotrellis/geotrellis-server/pull/293)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,6 +94,6 @@ object Dependencies {
   val shapeless = "com.chuusai" %% "shapeless" % shapelessVer
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % Runtime
   val droste = "io.higherkindness" %% "droste-core" % "0.8.0"
-  val stac4s = "com.azavea.stac4s" %% "core" % "0.0.10"
+  val stac4s = "com.azavea.stac4s" %% "core" % "0.0.11"
   val ansiColors212 = "org.backuity" %% "ansi-interpolator" % "1.1.0" % Provided
 }

--- a/stac-example/Makefile
+++ b/stac-example/Makefile
@@ -10,7 +10,7 @@ postgres:
 migrations:
 	docker run \
       --network stac-example_default \
-      quay.io/azavea/franklin:25aa7b5 \
+      quay.io/azavea/franklin:538d079 \
       migrate \
       --db-user franklin \
       --db-name franklin \
@@ -22,7 +22,7 @@ import-test-catalog:
       --network stac-example_default \
       -e AWS_REGION=us-east-1 \
       -v ${PWD}/catalog:/opt/data/ \
-      quay.io/azavea/franklin:25aa7b5 \
+      quay.io/azavea/franklin:538d079 \
       import \
       --db-user franklin \
       --db-name franklin \
@@ -35,7 +35,7 @@ run-franklin:
       --network stac-example_default \
       -p 9090:9090 \
       -d \
-      quay.io/azavea/franklin:25aa7b5 \
+      quay.io/azavea/franklin:538d079 \
       serve \
       --db-user franklin \
       --db-name franklin \

--- a/stac-example/catalog/landsat-stac-layers/catalog.json
+++ b/stac-example/catalog/landsat-stac-layers/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [],
   "id" : "landsat-stac-layers",
   "title" : "STAC for Landsat data",

--- a/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-05/LC80150322018141LGN00.json
+++ b/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-05/LC80150322018141LGN00.json
@@ -1,10 +1,11 @@
 {
   "type": "Feature",
   "id": "LC80150322018141LGN00",
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [
     "eo",
     "view",
+    "proj",
     "layers",
     "https://example.com/stac/landsat-extension/1.0/schema.json"
   ],
@@ -46,20 +47,20 @@
     "collection": "landsat-8-l1",
     "layer:ids" : ["layer-us", "layer-pa"],
     "datetime": "2018-05-21T15:44:59Z",
-    "eo:sun_azimuth": 134.8082647,
-    "eo:sun_elevation": 64.00406717,
+    "view:sun_azimuth": 134.8082647,
+    "view:sun_elevation": 64.00406717,
     "eo:cloud_cover": 4,
-    "eo:row": "032",
-    "eo:column": "015",
+    "landsat:row": "032",
+    "landsat:column": "015",
     "landsat:product_id": "LC08_L1TP_015032_20180521_20180605_01_T1",
     "landsat:scene_id": "LC80150322018141LGN00",
     "landsat:processing_level": "L1TP",
     "landsat:tier": "T1",
-    "eo:epsg": 32618,
-    "eo:instrument": "OLI_TIRS",
-    "eo:off_nadir": 0,
-    "eo:platform": "landsat-8",
-    "eo:gsd": 15
+    "proj:epsg": 32618,
+    "instruments": ["OLI_TIRS"],
+    "view:off_nadir": 0,
+    "platform": "landsat-8",
+    "gsd": 15
   },
   "assets": {
     "index": {
@@ -78,102 +79,157 @@
     },
     "B1": {
       "type": "image/tiff",
-      "eo:bands": [
-        0
-      ],
       "title": "Band 1 (coastal)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B1.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B1",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 0.44,
+          "common_name" : "coastal"
+        }
+      ]
     },
     "B2": {
       "type": "image/tiff",
-      "eo:bands": [
-        1
-      ],
       "title": "Band 2 (blue)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B2.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B2",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.48,
+          "common_name" : "blue"
+        }
+      ]
     },
     "B3": {
       "type": "image/tiff",
-      "eo:bands": [
-        2
-      ],
       "title": "Band 3 (green)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B3.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B3",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.56,
+          "common_name" : "green"
+        }
+      ]
     },
     "B4": {
       "type": "image/tiff",
-      "eo:bands": [
-        3
-      ],
       "title": "Band 4 (red)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B4.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B4",
+          "full_width_half_max" : 0.04,
+          "center_wavelength" : 0.65,
+          "common_name" : "red"
+        }
+      ]
     },
     "B5": {
       "type": "image/tiff",
-      "eo:bands": [
-        4
-      ],
       "title": "Band 5 (nir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B5.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B5",
+          "full_width_half_max" : 0.03,
+          "center_wavelength" : 0.86,
+          "common_name" : "nir"
+        }
+      ]
     },
     "B6": {
       "type": "image/tiff",
-      "eo:bands": [
-        5
-      ],
       "title": "Band 6 (swir16)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B6.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B6",
+          "full_width_half_max" : 0.08,
+          "center_wavelength" : 1.6,
+          "common_name" : "swir16"
+        }
+      ]
     },
     "B7": {
       "type": "image/tiff",
-      "eo:bands": [
-        6
-      ],
       "title": "Band 7 (swir22)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B7.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B7",
+          "full_width_half_max" : 0.22,
+          "center_wavelength" : 2.2,
+          "common_name" : "swir22"
+        }
+      ]
     },
     "B8": {
       "type": "image/tiff",
-      "eo:bands": [
-        7
-      ],
       "title": "Band 8 (pan)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B8.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B8",
+          "full_width_half_max" : 0.18,
+          "center_wavelength" : 0.59,
+          "common_name" : "pan"
+        }
+      ]
     },
     "B9": {
       "type": "image/tiff",
-      "eo:bands": [
-        8
-      ],
       "title": "Band 9 (cirrus)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B9.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B9",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 1.37,
+          "common_name" : "cirrus"
+        }
+      ]
     },
     "B10": {
       "type": "image/tiff",
-      "eo:bands": [
-        9
-      ],
       "title": "Band 10 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B10.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B10",
+          "full_width_half_max" : 0.8,
+          "center_wavelength" : 10.9,
+          "common_name" : "lwir11"
+        }
+      ]
     },
     "B11": {
       "type": "image/tiff",
-      "eo:bands": [
-        10
-      ],
       "title": "Band 11 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/032/LC08_L1TP_015032_20180521_20180605_01_T1/LC08_L1TP_015032_20180521_20180605_01_T1_B11.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B11",
+          "full_width_half_max" : 1,
+          "center_wavelength" : 12,
+          "common_name" : "lwir2"
+        }
+      ]
     },
     "ANG": {
       "title": "Angle coefficients file",

--- a/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-06/LC80140332018166LGN00.json
+++ b/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-06/LC80140332018166LGN00.json
@@ -1,10 +1,11 @@
 {
   "type": "Feature",
   "id": "LC80140332018166LGN00",
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [
     "eo",
     "view",
+    "proj",
     "layers",
     "https://example.com/stac/landsat-extension/1.0/schema.json"
   ],
@@ -46,20 +47,20 @@
     "collection": "landsat-8-l1",
     "layer:ids" : ["layer-us", "layer-pa"],
     "datetime": "2018-06-15T15:39:09Z",
-    "eo:sun_azimuth": 125.59055137,
-    "eo:sun_elevation": 66.54485226,
+    "view:sun_azimuth": 125.59055137,
+    "view:sun_elevation": 66.54485226,
     "eo:cloud_cover": 22,
-    "eo:row": "033",
-    "eo:column": "014",
+    "landsat:row": "033",
+    "landsat:column": "014",
     "landsat:product_id": "LC08_L1TP_014033_20180615_20180703_01_T1",
     "landsat:scene_id": "LC80140332018166LGN00",
     "landsat:processing_level": "L1TP",
     "landsat:tier": "T1",
-    "eo:epsg": 32618,
-    "eo:instrument": "OLI_TIRS",
-    "eo:off_nadir": 0,
-    "eo:platform": "landsat-8",
-    "eo:gsd": 15
+    "proj:epsg": 32618,
+    "instruments": ["OLI_TIRS"],
+    "view:off_nadir": 0,
+    "platform": "landsat-8",
+    "gsd": 15
   },
   "assets": {
     "index": {
@@ -78,102 +79,157 @@
     },
     "B1": {
       "type": "image/tiff",
-      "eo:bands": [
-        0
-      ],
       "title": "Band 1 (coastal)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B1.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B1",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 0.44,
+          "common_name" : "coastal"
+        }
+      ]
     },
     "B2": {
       "type": "image/tiff",
-      "eo:bands": [
-        1
-      ],
       "title": "Band 2 (blue)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B2.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B2",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.48,
+          "common_name" : "blue"
+        }
+      ]
     },
     "B3": {
       "type": "image/tiff",
-      "eo:bands": [
-        2
-      ],
       "title": "Band 3 (green)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B3.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B3",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.56,
+          "common_name" : "green"
+        }
+      ]
     },
     "B4": {
       "type": "image/tiff",
-      "eo:bands": [
-        3
-      ],
       "title": "Band 4 (red)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B4.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B4",
+          "full_width_half_max" : 0.04,
+          "center_wavelength" : 0.65,
+          "common_name" : "red"
+        }
+      ]
     },
     "B5": {
       "type": "image/tiff",
-      "eo:bands": [
-        4
-      ],
       "title": "Band 5 (nir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B5.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B5",
+          "full_width_half_max" : 0.03,
+          "center_wavelength" : 0.86,
+          "common_name" : "nir"
+        }
+      ]
     },
     "B6": {
       "type": "image/tiff",
-      "eo:bands": [
-        5
-      ],
       "title": "Band 6 (swir16)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B6.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B6",
+          "full_width_half_max" : 0.08,
+          "center_wavelength" : 1.6,
+          "common_name" : "swir16"
+        }
+      ]
     },
     "B7": {
       "type": "image/tiff",
-      "eo:bands": [
-        6
-      ],
       "title": "Band 7 (swir22)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B7.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B7",
+          "full_width_half_max" : 0.22,
+          "center_wavelength" : 2.2,
+          "common_name" : "swir22"
+        }
+      ]
     },
     "B8": {
       "type": "image/tiff",
-      "eo:bands": [
-        7
-      ],
       "title": "Band 8 (pan)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B8.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B8",
+          "full_width_half_max" : 0.18,
+          "center_wavelength" : 0.59,
+          "common_name" : "pan"
+        }
+      ]
     },
     "B9": {
       "type": "image/tiff",
-      "eo:bands": [
-        8
-      ],
       "title": "Band 9 (cirrus)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B9.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B9",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 1.37,
+          "common_name" : "cirrus"
+        }
+      ]
     },
     "B10": {
       "type": "image/tiff",
-      "eo:bands": [
-        9
-      ],
       "title": "Band 10 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B10.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B10",
+          "full_width_half_max" : 0.8,
+          "center_wavelength" : 10.9,
+          "common_name" : "lwir11"
+        }
+      ]
     },
     "B11": {
       "type": "image/tiff",
-      "eo:bands": [
-        10
-      ],
       "title": "Band 11 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/014/033/LC08_L1TP_014033_20180615_20180703_01_T1/LC08_L1TP_014033_20180615_20180703_01_T1_B11.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B11",
+          "full_width_half_max" : 1,
+          "center_wavelength" : 12,
+          "common_name" : "lwir2"
+        }
+      ]
     },
     "ANG": {
       "title": "Angle coefficients file",

--- a/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-06/LC80300332018166LGN00.json
+++ b/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-06/LC80300332018166LGN00.json
@@ -1,9 +1,10 @@
 {
   "type": "Feature",
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [
     "eo",
     "view",
+    "proj",
     "layers",
     "https://example.com/stac/landsat-extension/1.0/schema.json"
   ],
@@ -46,20 +47,20 @@
     "collection": "landsat-8-l1",
     "layer:ids" : ["layer-us"],
     "datetime": "2018-06-15T17:18:03Z",
-    "eo:sun_azimuth": 125.5799919,
-    "eo:sun_elevation": 66.54407242,
+    "view:sun_azimuth": 125.5799919,
+    "view:sun_elevation": 66.54407242,
     "eo:cloud_cover": 0,
-    "eo:row": "033",
-    "eo:column": "030",
+    "landsat:row": "033",
+    "landsat:column": "030",
     "landsat:product_id": "LC08_L1TP_030033_20180615_20180703_01_T1",
     "landsat:scene_id": "LC80300332018166LGN00",
     "landsat:processing_level": "L1TP",
     "landsat:tier": "T1",
-    "eo:epsg": 32614,
-    "eo:instrument": "OLI_TIRS",
-    "eo:off_nadir": 0,
-    "eo:platform": "landsat-8",
-    "eo:gsd": 15
+    "proj:epsg": 32614,
+    "instruments": ["OLI_TIRS"],
+    "view:off_nadir": 0,
+    "platform": "landsat-8",
+    "gsd": 15
   },
   "assets": {
     "index": {
@@ -78,102 +79,157 @@
     },
     "B1": {
       "type": "image/tiff",
-      "eo:bands": [
-        0
-      ],
       "title": "Band 1 (coastal)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B1.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B1",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 0.44,
+          "common_name" : "coastal"
+        }
+      ]
     },
     "B2": {
       "type": "image/tiff",
-      "eo:bands": [
-        1
-      ],
       "title": "Band 2 (blue)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B2.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B2",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.48,
+          "common_name" : "blue"
+        }
+      ]
     },
     "B3": {
       "type": "image/tiff",
-      "eo:bands": [
-        2
-      ],
       "title": "Band 3 (green)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B3.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B3",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.56,
+          "common_name" : "green"
+        }
+      ]
     },
     "B4": {
       "type": "image/tiff",
-      "eo:bands": [
-        3
-      ],
       "title": "Band 4 (red)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B4.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B4",
+          "full_width_half_max" : 0.04,
+          "center_wavelength" : 0.65,
+          "common_name" : "red"
+        }
+      ]
     },
     "B5": {
       "type": "image/tiff",
-      "eo:bands": [
-        4
-      ],
       "title": "Band 5 (nir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B5.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B5",
+          "full_width_half_max" : 0.03,
+          "center_wavelength" : 0.86,
+          "common_name" : "nir"
+        }
+      ]
     },
     "B6": {
       "type": "image/tiff",
-      "eo:bands": [
-        5
-      ],
       "title": "Band 6 (swir16)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B6.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B6",
+          "full_width_half_max" : 0.08,
+          "center_wavelength" : 1.6,
+          "common_name" : "swir16"
+        }
+      ]
     },
     "B7": {
       "type": "image/tiff",
-      "eo:bands": [
-        6
-      ],
       "title": "Band 7 (swir22)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B7.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B7",
+          "full_width_half_max" : 0.22,
+          "center_wavelength" : 2.2,
+          "common_name" : "swir22"
+        }
+      ]
     },
     "B8": {
       "type": "image/tiff",
-      "eo:bands": [
-        7
-      ],
       "title": "Band 8 (pan)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B8.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B8",
+          "full_width_half_max" : 0.18,
+          "center_wavelength" : 0.59,
+          "common_name" : "pan"
+        }
+      ]
     },
     "B9": {
       "type": "image/tiff",
-      "eo:bands": [
-        8
-      ],
       "title": "Band 9 (cirrus)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B9.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B9",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 1.37,
+          "common_name" : "cirrus"
+        }
+      ]
     },
     "B10": {
       "type": "image/tiff",
-      "eo:bands": [
-        9
-      ],
       "title": "Band 10 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B10.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B10",
+          "full_width_half_max" : 0.8,
+          "center_wavelength" : 10.9,
+          "common_name" : "lwir11"
+        }
+      ]
     },
     "B11": {
       "type": "image/tiff",
-      "eo:bands": [
-        10
-      ],
       "title": "Band 11 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/030/033/LC08_L1TP_030033_20180615_20180703_01_T1/LC08_L1TP_030033_20180615_20180703_01_T1_B11.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B11",
+          "full_width_half_max" : 1,
+          "center_wavelength" : 12,
+          "common_name" : "lwir2"
+        }
+      ]
     },
     "ANG": {
       "title": "Angle coefficients file",

--- a/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-07/LC80150332018189LGN00.json
+++ b/stac-example/catalog/landsat-stac-layers/landsat-8-l1/2018-07/LC80150332018189LGN00.json
@@ -1,10 +1,11 @@
 {
   "type": "Feature",
   "id": "LC80150332018189LGN00",
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [
     "eo",
     "view",
+    "proj",
     "layers",
     "https://example.com/stac/landsat-extension/1.0/schema.json"
   ],
@@ -46,20 +47,20 @@
     "collection": "landsat-8-l1",
     "layer:ids" : ["layer-us", "layer-pa"],
     "datetime": "2018-07-08T15:45:34Z",
-    "eo:sun_azimuth": 125.31095515,
-    "eo:sun_elevation": 65.2014335,
+    "view:sun_azimuth": 125.31095515,
+    "view:sun_elevation": 65.2014335,
     "eo:cloud_cover": 0,
-    "eo:row": "033",
-    "eo:column": "015",
+    "landsat:row": "033",
+    "landsat:column": "015",
     "landsat:product_id": "LC08_L1TP_015033_20180708_20180717_01_T1",
     "landsat:scene_id": "LC80150332018189LGN00",
     "landsat:processing_level": "L1TP",
     "landsat:tier": "T1",
-    "eo:epsg": 32618,
-    "eo:instrument": "OLI_TIRS",
-    "eo:off_nadir": 0,
-    "eo:platform": "landsat-8",
-    "eo:gsd": 15
+    "proj:epsg": 32618,
+    "instruments": ["OLI_TIRS"],
+    "view:off_nadir": 0,
+    "platform": "landsat-8",
+    "gsd": 15
   },
   "assets": {
     "index": {
@@ -78,102 +79,157 @@
     },
     "B1": {
       "type": "image/tiff",
-      "eo:bands": [
-        0
-      ],
       "title": "Band 1 (coastal)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B1.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B1",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 0.44,
+          "common_name" : "coastal"
+        }
+      ]
     },
     "B2": {
       "type": "image/tiff",
-      "eo:bands": [
-        1
-      ],
       "title": "Band 2 (blue)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B2.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B2",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.48,
+          "common_name" : "blue"
+        }
+      ]
     },
     "B3": {
       "type": "image/tiff",
-      "eo:bands": [
-        2
-      ],
       "title": "Band 3 (green)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B3.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B3",
+          "full_width_half_max" : 0.06,
+          "center_wavelength" : 0.56,
+          "common_name" : "green"
+        }
+      ]
     },
     "B4": {
       "type": "image/tiff",
-      "eo:bands": [
-        3
-      ],
       "title": "Band 4 (red)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B4.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B4",
+          "full_width_half_max" : 0.04,
+          "center_wavelength" : 0.65,
+          "common_name" : "red"
+        }
+      ]
     },
     "B5": {
       "type": "image/tiff",
-      "eo:bands": [
-        4
-      ],
       "title": "Band 5 (nir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B5.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B5",
+          "full_width_half_max" : 0.03,
+          "center_wavelength" : 0.86,
+          "common_name" : "nir"
+        }
+      ]
     },
     "B6": {
       "type": "image/tiff",
-      "eo:bands": [
-        5
-      ],
       "title": "Band 6 (swir16)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B6.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B6",
+          "full_width_half_max" : 0.08,
+          "center_wavelength" : 1.6,
+          "common_name" : "swir16"
+        }
+      ]
     },
     "B7": {
       "type": "image/tiff",
-      "eo:bands": [
-        6
-      ],
       "title": "Band 7 (swir22)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B7.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B7",
+          "full_width_half_max" : 0.22,
+          "center_wavelength" : 2.2,
+          "common_name" : "swir22"
+        }
+      ]
     },
     "B8": {
       "type": "image/tiff",
-      "eo:bands": [
-        7
-      ],
       "title": "Band 8 (pan)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B8.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B8",
+          "full_width_half_max" : 0.18,
+          "center_wavelength" : 0.59,
+          "common_name" : "pan"
+        }
+      ]
     },
     "B9": {
       "type": "image/tiff",
-      "eo:bands": [
-        8
-      ],
       "title": "Band 9 (cirrus)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B9.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B9",
+          "full_width_half_max" : 0.02,
+          "center_wavelength" : 1.37,
+          "common_name" : "cirrus"
+        }
+      ]
     },
     "B10": {
       "type": "image/tiff",
-      "eo:bands": [
-        9
-      ],
       "title": "Band 10 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B10.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B10",
+          "full_width_half_max" : 0.8,
+          "center_wavelength" : 10.9,
+          "common_name" : "lwir11"
+        }
+      ]
     },
     "B11": {
       "type": "image/tiff",
-      "eo:bands": [
-        10
-      ],
       "title": "Band 11 (lwir)",
       "href": "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/015/033/LC08_L1TP_015033_20180708_20180717_01_T1/LC08_L1TP_015033_20180708_20180717_01_T1_B11.TIF",
-      "roles": []
+      "roles": [],
+      "eo:bands": [
+        {
+          "name" : "B11",
+          "full_width_half_max" : 1,
+          "center_wavelength" : 12,
+          "common_name" : "lwir2"
+        }
+      ]
     },
     "ANG": {
       "title": "Angle coefficients file",

--- a/stac-example/catalog/landsat-stac-layers/landsat-8-l1/catalog.json
+++ b/stac-example/catalog/landsat-stac-layers/landsat-8-l1/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version" : "0.9.0",
+  "stac_version" : "1.0.0-beta.1",
   "stac_extensions" : [
     "eo",
     "view",
@@ -43,93 +43,83 @@
       ]
     }
   },
+  "summaries": {},
   "properties" : {
     "collection" : "landsat-8-l1",
-    "eo:instrument" : "OLI_TIRS",
+    "instruments" : ["OLI_TIRS"],
     "view:sun_azimuth" : 149.01607154,
     "eo:bands" : [
       {
         "name" : "B1",
         "full_width_half_max" : 0.02,
         "center_wavelength" : 0.44,
-        "common_name" : "coastal",
-        "gsd" : 30
+        "common_name" : "coastal"
       },
       {
         "name" : "B2",
         "full_width_half_max" : 0.06,
         "center_wavelength" : 0.48,
-        "common_name" : "blue",
-        "gsd" : 30
+        "common_name" : "blue"
       },
       {
         "name" : "B3",
         "full_width_half_max" : 0.06,
         "center_wavelength" : 0.56,
-        "common_name" : "green",
-        "gsd" : 30
+        "common_name" : "green"
       },
       {
         "name" : "B4",
         "full_width_half_max" : 0.04,
         "center_wavelength" : 0.65,
-        "common_name" : "red",
-        "gsd" : 30
+        "common_name" : "red"
       },
       {
         "name" : "B5",
         "full_width_half_max" : 0.03,
         "center_wavelength" : 0.86,
-        "common_name" : "nir",
-        "gsd" : 30
+        "common_name" : "nir"
       },
       {
         "name" : "B6",
         "full_width_half_max" : 0.08,
         "center_wavelength" : 1.6,
-        "common_name" : "swir16",
-        "gsd" : 30
+        "common_name" : "swir16"
       },
       {
         "name" : "B7",
         "full_width_half_max" : 0.22,
         "center_wavelength" : 2.2,
-        "common_name" : "swir22",
-        "gsd" : 30
+        "common_name" : "swir22"
       },
       {
         "name" : "B8",
         "full_width_half_max" : 0.18,
         "center_wavelength" : 0.59,
-        "common_name" : "pan",
-        "gsd" : 30
+        "common_name" : "pan"
       },
       {
         "name" : "B9",
         "full_width_half_max" : 0.02,
         "center_wavelength" : 1.37,
-        "common_name" : "cirrus",
-        "gsd" : 30
+        "common_name" : "cirrus"
       },
       {
         "name" : "B10",
         "full_width_half_max" : 0.8,
         "center_wavelength" : 10.9,
-        "common_name" : "lwir11",
-        "gsd" : 100
+        "common_name" : "lwir11"
       },
       {
         "name" : "B11",
         "full_width_half_max" : 1,
         "center_wavelength" : 12,
-        "common_name" : "lwir2",
-        "gsd" : 100
+        "common_name" : "lwir2"
       }
     ],
     "view:off_nadir" : 0,
     "view:azimuth" : 0,
-    "eo:platform" : "landsat-8",
-    "eo:gsd" : 15,
+    "platform" : "landsat-8",
+    "gsd" : 15,
     "view:sun_elevation" : 59.214247
   },
   "links" : [

--- a/stac-example/catalog/landsat-stac-layers/layers/pa/catalog.json
+++ b/stac-example/catalog/landsat-stac-layers/layers/pa/catalog.json
@@ -1,10 +1,6 @@
 {
-  "stac_version" : "0.9.0",
-  "stac_extensions" : [
-    "eo",
-    "view",
-    "https://example.com/stac/landsat-extension/1.0/schema.json"
-  ],
+  "stac_version" : "1.0.0-beta.1",
+  "stac_extensions" : [],
   "id" : "layer-pa",
   "title" : "Landsat 8 L1",
   "description" : "PA STAC Layer",

--- a/stac-example/catalog/landsat-stac-layers/layers/us/catalog.json
+++ b/stac-example/catalog/landsat-stac-layers/layers/us/catalog.json
@@ -1,10 +1,6 @@
 {
-  "stac_version" : "0.9.0",
-  "stac_extensions" : [
-    "eo",
-    "view",
-    "https://example.com/stac/landsat-extension/1.0/schema.json"
-  ],
+  "stac_version" : "1.0.0-beta.1",
+  "stac_extensions" : [],
   "id" : "layer-us",
   "title" : "Landsat 8 L1",
   "description" : "US STAC Layer",

--- a/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
+++ b/stac-example/src/main/scala/geotrellis/stac/api/SearchFilters.scala
@@ -119,7 +119,7 @@ object SearchFilters {
       )
     }
 
-    implicit val geometryIntersectionSemigroup: Semigroup[Geometry] = { (left, right) => left.intersection(right) }
+    implicit val geometryIntersectionSemigroup: Semigroup[Geometry] = { _ intersection _ }
 
     implicit val searchFiltersSemigroup: Semigroup[SearchFilters] = { (left, right) =>
       SearchFilters(
@@ -159,7 +159,7 @@ object SearchFilters {
       )
     }
 
-    implicit val geometryUnionSemigroup: Semigroup[Geometry] = { (left, right) => left.union(right) }
+    implicit val geometryUnionSemigroup: Semigroup[Geometry] = { _ union _ }
 
     implicit val searchFiltersSemigroup: Semigroup[SearchFilters] = { (left, right) =>
       SearchFilters(


### PR DESCRIPTION
## Overview

This PR updates STAC4s dependency to support STAC 1.0.0-beta.1 and updates test catalogs

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible
