### PR TITLE
Include default namespace in XML responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pc.stdout.log
 .metals
 metals.sbt
 .history
+.bsp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Fix STAC API TemporalExtent JSON representation [#293](https://github.com/geotrellis/geotrellis-server/pull/293)
+- XML responses in OGC services include a default namespace [#311](https://github.com/geotrellis/geotrellis-server/pull/311)
 
 ## [4.2.0] - 2020-06-23
 

--- a/ogc-example/docs/usage.md
+++ b/ogc-example/docs/usage.md
@@ -23,9 +23,9 @@ Start SBT
 > ./sbt
 ```
 
-Navigate to the `ogcExample` project
+Navigate to the `ogc-example` project
 ```sh
-root > project ogcExample
+root > project ogc-example
 ```
 
 Fire up the server with some sane defaults for local clients (using 127.0.0.1

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CapabilitiesView.scala
@@ -218,7 +218,7 @@ class CapabilitiesView[F[_]: Functor](wcsModel: WcsModel[F], serviceUrl: URL, ex
           ),
           namespace = None,
           elementLabel = "Capabilities".some,
-          scope = constrainedWCSScope,
+          scope = wcsScope,
           typeAttribute = false
         )
         .asInstanceOf[Elem]

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
@@ -48,7 +48,7 @@ class CoverageView[F[_]: Functor](wcsModel: WcsModel[F], serviceUrl: URL, identi
           obj = CoverageDescriptions(coverageType.values.toList),
           namespace = None,
           elementLabel = "CoverageDescriptions".some,
-          scope = constrainedWCSScope,
+          scope = wcsScope,
           typeAttribute = false
         )
         .asInstanceOf[Elem]

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/package.scala
@@ -30,15 +30,6 @@ package object wcs {
     Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
   )
 
-  val constrainedWCSScope: NamespaceBinding = scalaxb.toScope(
-    None          -> "http://www.opengis.net/wcs/1.1.1",
-    Some("gml")   -> "http://www.opengis.net/gml",
-    Some("ows")   -> "http://www.opengis.net/ows/1.1",
-    Some("ogc")   -> "http://www.opengis.net/ogc",
-    Some("xlink") -> "http://www.w3.org/1999/xlink",
-    Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
-  )
-
   implicit class ExtentOps(self: Extent) {
     def swapXY: Extent = Extent(xmin = self.ymin, ymin = self.xmin, xmax = self.ymax, ymax = self.xmax)
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/package.scala
@@ -22,15 +22,16 @@ import scala.xml.NamespaceBinding
 
 package object wcs {
   val wcsScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wcs/1.1.1",
     Some("gml")   -> "http://www.opengis.net/gml",
     Some("ows")   -> "http://www.opengis.net/ows/1.1",
     Some("ogc")   -> "http://www.opengis.net/ogc",
-    Some("wcs")   -> "http://www.opengis.net/wcs/1.1.1",
     Some("xlink") -> "http://www.w3.org/1999/xlink",
     Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
   )
 
   val constrainedWCSScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wcs/1.1.1",
     Some("gml")   -> "http://www.opengis.net/gml",
     Some("ows")   -> "http://www.opengis.net/ows/1.1",
     Some("ogc")   -> "http://www.opengis.net/ogc",

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -233,7 +233,7 @@ object CapabilitiesView {
         MinScaleDenominator = None,
         MaxScaleDenominator = None,
         Layer = Nil,
-        attributes = Map("@queryable" -> DataRecord(false))
+        attributes = Map.empty
       )
     }
   }
@@ -324,7 +324,7 @@ object CapabilitiesView {
           MinScaleDenominator = None,
           MaxScaleDenominator = None,
           Layer = layers,
-          attributes = Map("@queryable" -> DataRecord(false))
+          attributes = Map.empty
         )
     }
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/CapabilitiesView.scala
@@ -105,7 +105,7 @@ class CapabilitiesView[F[_]: Functor: Apply: Monad](model: WmsModel[F], serviceU
           ),
           namespace = None,
           elementLabel = "WMS_Capabilities".some,
-          scope = constrainedWMSScope,
+          scope = wmsScope,
           typeAttribute = false
         )
         .asInstanceOf[scala.xml.Elem]

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
@@ -28,13 +28,6 @@ import java.net.URI
 import scala.xml.{Elem, NamespaceBinding, NodeSeq}
 
 package object wms {
-  val wmsScope: NamespaceBinding = scalaxb.toScope(
-    None          -> "http://www.opengis.net/wms",
-    Some("ogc")   -> "http://www.opengis.net/ogc",
-    Some("xlink") -> "http://www.w3.org/1999/xlink",
-    Some("xs")    -> "http://www.w3.org/2001/XMLSchema",
-    Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
-  )
 
   /**
     * Default scope generates an incorrect XML file (in the incorrect scope, prefixes all XML elements with `wms:` prefix.
@@ -45,7 +38,7 @@ package object wms {
     * Some("xs") -> "http://www.w3.org/2001/XMLSchema",
     * Some("xsi") -> "http://www.w3.org/2001/XMLSchema-instance")
     */
-  val constrainedWMSScope: NamespaceBinding = scalaxb.toScope(
+  val wmsScope: NamespaceBinding = scalaxb.toScope(
     None          -> "http://www.opengis.net/wms",
     Some("ogc")   -> "http://www.opengis.net/ogc",
     Some("xlink") -> "http://www.w3.org/1999/xlink",

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/package.scala
@@ -29,8 +29,8 @@ import scala.xml.{Elem, NamespaceBinding, NodeSeq}
 
 package object wms {
   val wmsScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wms",
     Some("ogc")   -> "http://www.opengis.net/ogc",
-    Some("wms")   -> "http://www.opengis.net/wms",
     Some("xlink") -> "http://www.w3.org/1999/xlink",
     Some("xs")    -> "http://www.w3.org/2001/XMLSchema",
     Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
@@ -46,6 +46,7 @@ package object wms {
     * Some("xsi") -> "http://www.w3.org/2001/XMLSchema-instance")
     */
   val constrainedWMSScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wms",
     Some("ogc")   -> "http://www.opengis.net/ogc",
     Some("xlink") -> "http://www.w3.org/1999/xlink",
     Some("xs")    -> "http://www.w3.org/2001/XMLSchema",

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/CapabilitiesView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/CapabilitiesView.scala
@@ -165,7 +165,7 @@ class CapabilitiesView[F[_]: Monad](wmtsModel: WmtsModel[F], serviceUrl: URL) {
           ),
           namespace = None,
           elementLabel = "Capabilities".some,
-          scope = constrainedWMTSScope,
+          scope = wmtsScope,
           typeAttribute = false
         )
         .asInstanceOf[scala.xml.Elem]

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
@@ -26,12 +26,4 @@ package object wmts {
     Some("xlink") -> "http://www.w3.org/1999/xlink",
     Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
   )
-
-  val constrainedWMTSScope: NamespaceBinding = scalaxb.toScope(
-    None          -> "http://www.opengis.net/wmts/1.0",
-    Some("gml")   -> "http://www.opengis.net/gml",
-    Some("ows")   -> "http://www.opengis.net/ows/1.1",
-    Some("xlink") -> "http://www.w3.org/1999/xlink",
-    Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
-  )
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
@@ -28,7 +28,7 @@ package object wmts {
   )
 
   val constrainedWMTSScope: NamespaceBinding = scalaxb.toScope(
-    None          -> "http://www.opengis.net/wmts/1.0",  
+    None          -> "http://www.opengis.net/wmts/1.0",
     Some("gml")   -> "http://www.opengis.net/gml",
     Some("ows")   -> "http://www.opengis.net/ows/1.1",
     Some("xlink") -> "http://www.w3.org/1999/xlink",

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/package.scala
@@ -20,14 +20,15 @@ import scala.xml.NamespaceBinding
 
 package object wmts {
   val wmtsScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wmts/1.0",
     Some("gml")   -> "http://www.opengis.net/gml",
     Some("ows")   -> "http://www.opengis.net/ows/1.1",
-    Some("wmts")  -> "http://www.opengis.net/wmts/1.0",
     Some("xlink") -> "http://www.w3.org/1999/xlink",
     Some("xsi")   -> "http://www.w3.org/2001/XMLSchema-instance"
   )
 
   val constrainedWMTSScope: NamespaceBinding = scalaxb.toScope(
+    None          -> "http://www.opengis.net/wmts/1.0",  
     Some("gml")   -> "http://www.opengis.net/gml",
     Some("ows")   -> "http://www.opengis.net/ows/1.1",
     Some("xlink") -> "http://www.w3.org/1999/xlink",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,73 +3,74 @@ import sbt.Keys._
 
 object Dependencies {
 
-  def catsVersion(module: String) = Def.setting {
-    module match {
-      case "core" =>"org.typelevel" %% s"cats-$module" % "2.1.1"
-      case "effect" =>"org.typelevel" %% s"cats-$module" % "2.1.3"
+  def catsVersion(module: String) =
+    Def.setting {
+      module match {
+        case "core"   => "org.typelevel" %% s"cats-$module" % "2.1.1"
+        case "effect" => "org.typelevel" %% s"cats-$module" % "2.1.3"
+      }
     }
-  }
 
   def circeVersion(module: String) = Def.setting { "io.circe" %% s"circe-$module" % "0.13.0" }
-  def http4sVer(module: String) = Def.setting { "org.http4s" %% s"http4s-$module" % "0.21.7" }
+  def http4sVer(module: String)    = Def.setting { "org.http4s" %% s"http4s-$module" % "0.21.7" }
 
   val crossScalaVer = List("2.12.12")
-  val scalaVer = crossScalaVer.head
+  val scalaVer      = crossScalaVer.head
 
-  val dispatchVer = "0.11.3"
-  val gtVer = "3.5.2"
-  val jaxbApiVer = "2.3.1"
-  val refinedVer = "0.9.9"
+  val dispatchVer  = "0.11.3"
+  val gtVer        = "3.5.2"
+  val jaxbApiVer   = "2.3.1"
+  val refinedVer   = "0.9.9"
   val shapelessVer = "2.3.3"
-  val sttpVer = "1.7.2"
-  val tsecVer = "0.0.1-M11"
+  val sttpVer      = "1.7.2"
+  val tsecVer      = "0.0.1-M11"
 
-  val cats = catsVersion("core")
-  val catsEffect = catsVersion("effect")
-  val circeCore = circeVersion("core")
-  val circeShapes = circeVersion("shapes")
-  val circeGeneric = circeVersion("generic")
-  val circeOptics = Def.setting { "io.circe" %% "circe-optics" % "0.13.0" }
-  val circeParser = circeVersion("parser")
-  val circeRefined = circeVersion("refined")
-  val circeJava8 = circeVersion("java8")
-  val commonsIO = "commons-io" % "commons-io" % "2.7"
-  val concHashMap = "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4.2"
-  val decline = "com.monovore" %% "decline" % "1.2.0"
-  val geotrellisRaster = "org.locationtech.geotrellis" %% "geotrellis-raster" % gtVer
-  val geotrellisLayer = "org.locationtech.geotrellis" %% "geotrellis-layer" % gtVer
-  val geotrellisVector = "org.locationtech.geotrellis" %% "geotrellis-vector" % gtVer
-  val geotrellisS3 = "org.locationtech.geotrellis" %% "geotrellis-s3" % gtVer
-  val geotrellisStore = "org.locationtech.geotrellis" %% "geotrellis-store" % gtVer
-  val geotrellisHBase = "org.locationtech.geotrellis" %% "geotrellis-hbase" % gtVer
-  val geotrellisAccumulo = "org.locationtech.geotrellis" %% "geotrellis-accumulo" % gtVer
-  val geotrellisCassandra = "org.locationtech.geotrellis" %% "geotrellis-cassandra" % gtVer
-  val geotrellisGdal = "org.locationtech.geotrellis" %% "geotrellis-gdal" % gtVer
-  val http4sBlazeClient = http4sVer("blaze-client")
-  val http4sBlazeServer = http4sVer("blaze-server")
-  val http4sCirce = http4sVer("circe")
-  val http4sDsl = http4sVer("dsl")
-  val http4sXml = http4sVer("scala-xml")
-  val jaxbApi = "javax.xml.bind" % "jaxb-api" % jaxbApiVer
-  val kindProjector = "org.typelevel" %% "kind-projector" % "0.11.0"
-  val semanticdbScalac = "org.scalameta" % "semanticdb-scalac" % "4.3.20"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j" % "1.1.1"
-  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % "0.6.1"
-  val pureConfig = "com.github.pureconfig" %% "pureconfig" % "0.13.0"
-  val pureConfigCatsEffect = "com.github.pureconfig" %% "pureconfig-cats-effect" % "0.13.0"
-  val scaffeine = "com.github.blemale" %% "scaffeine" % "4.0.1"
-  val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.1" % Test
-  val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
-  val scalacheckCats = "io.chrisdavenport" %% "cats-scalacheck" % "0.1.1" % Test
-  val sttp = "com.softwaremill.sttp" %% "core" % sttpVer
-  val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVer
-  val sttpCats = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % sttpVer
-  val macrosParadise = "org.scalamacros" % "paradise" % "2.1.1"
-  val scalaParser = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
-  val shapeless = "com.chuusai" %% "shapeless" % shapelessVer
-  val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % Runtime
-  val droste = "io.higherkindness" %% "droste-core" % "0.8.0"
-  val stac4s = "com.azavea.stac4s" %% "core" % "0.0.14"
-  val ansiColors212 = "org.backuity" %% "ansi-interpolator" % "1.1.0" % Provided
+  val cats                 = catsVersion("core")
+  val catsEffect           = catsVersion("effect")
+  val circeCore            = circeVersion("core")
+  val circeShapes          = circeVersion("shapes")
+  val circeGeneric         = circeVersion("generic")
+  val circeOptics          = Def.setting { "io.circe" %% "circe-optics" % "0.13.0" }
+  val circeParser          = circeVersion("parser")
+  val circeRefined         = circeVersion("refined")
+  val circeJava8           = circeVersion("java8")
+  val commonsIO            = "commons-io"                             % "commons-io"                     % "2.7"
+  val concHashMap          = "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru"    % "1.4.2"
+  val decline              = "com.monovore"                          %% "decline"                        % "1.2.0"
+  val geotrellisRaster     = "org.locationtech.geotrellis"           %% "geotrellis-raster"              % gtVer
+  val geotrellisLayer      = "org.locationtech.geotrellis"           %% "geotrellis-layer"               % gtVer
+  val geotrellisVector     = "org.locationtech.geotrellis"           %% "geotrellis-vector"              % gtVer
+  val geotrellisS3         = "org.locationtech.geotrellis"           %% "geotrellis-s3"                  % gtVer
+  val geotrellisStore      = "org.locationtech.geotrellis"           %% "geotrellis-store"               % gtVer
+  val geotrellisHBase      = "org.locationtech.geotrellis"           %% "geotrellis-hbase"               % gtVer
+  val geotrellisAccumulo   = "org.locationtech.geotrellis"           %% "geotrellis-accumulo"            % gtVer
+  val geotrellisCassandra  = "org.locationtech.geotrellis"           %% "geotrellis-cassandra"           % gtVer
+  val geotrellisGdal       = "org.locationtech.geotrellis"           %% "geotrellis-gdal"                % gtVer
+  val http4sBlazeClient    = http4sVer("blaze-client")
+  val http4sBlazeServer    = http4sVer("blaze-server")
+  val http4sCirce          = http4sVer("circe")
+  val http4sDsl            = http4sVer("dsl")
+  val http4sXml            = http4sVer("scala-xml")
+  val jaxbApi              = "javax.xml.bind"                         % "jaxb-api"                       % jaxbApiVer
+  val kindProjector        = "org.typelevel"                         %% "kind-projector"                 % "0.11.0"
+  val semanticdbScalac     = "org.scalameta"                          % "semanticdb-scalac"              % "4.3.20"
+  val log4cats             = "io.chrisdavenport"                     %% "log4cats-slf4j"                 % "1.1.1"
+  val mamlJvm              = "com.azavea.geotrellis"                 %% "maml-jvm"                       % "0.6.1"
+  val pureConfig           = "com.github.pureconfig"                 %% "pureconfig"                     % "0.13.0"
+  val pureConfigCatsEffect = "com.github.pureconfig"                 %% "pureconfig-cats-effect"         % "0.13.0"
+  val scaffeine            = "com.github.blemale"                    %% "scaffeine"                      % "4.0.1"
+  val scalaXml             = "org.scala-lang.modules"                %% "scala-xml"                      % "1.3.0"
+  val scalatest            = "org.scalatest"                         %% "scalatest"                      % "3.2.1"  % Test
+  val scalacheck           = "org.scalacheck"                        %% "scalacheck"                     % "1.14.0" % Test
+  val scalacheckCats       = "io.chrisdavenport"                     %% "cats-scalacheck"                % "0.1.1"  % Test
+  val sttp                 = "com.softwaremill.sttp"                 %% "core"                           % sttpVer
+  val sttpCirce            = "com.softwaremill.sttp"                 %% "circe"                          % sttpVer
+  val sttpCats             = "com.softwaremill.sttp"                 %% "async-http-client-backend-cats" % sttpVer
+  val macrosParadise       = "org.scalamacros"                        % "paradise"                       % "2.1.1"
+  val scalaParser          = "org.scala-lang.modules"                %% "scala-parser-combinators"       % "1.1.2"
+  val shapeless            = "com.chuusai"                           %% "shapeless"                      % shapelessVer
+  val logback              = "ch.qos.logback"                         % "logback-classic"                % "1.2.3"  % Runtime
+  val droste               = "io.higherkindness"                     %% "droste-core"                    % "0.8.0"
+  val stac4s               = "com.azavea.stac4s"                     %% "core"                           % "0.0.14"
+  val ansiColors212        = "org.backuity"                          %% "ansi-interpolator"              % "1.1.0"  % Provided
 }

--- a/scripts/test
+++ b/scripts/test
@@ -18,6 +18,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         usage
     else
         echo "Executing Scala test suite"
-        ./sbt "++${SCALA_VERSION:-2.12.12}" scalafmtCheck test
+        ./sbt "++${SCALA_VERSION:-2.12.12}" scalafmtCheck scalafmtSbtCheck test
     fi
 fi


### PR DESCRIPTION
## Overview

This PR throws OGC `wcs`, `wms`, and `wmts` namespaces into the `xmlns` attribute for XML responses for each service.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Notes

Testing could be improved for sure -- I don't know enough about `owslib` right now to do a great job crafting the example calls. Some problems I've run into are not knowing how to make a `GetCapabilities` request to any of the services / not knowing how to translate owslib `Operations` into owslib calls for xml that it wants to parse.

## Testing Instructions

- follow the instructions in `usage.md` to get the `ogc-example` up and running
- however you desire, get a nice isolated python environment, and `pip install` the following requirements file. pyproj is pinned because OWSLib does the `>=` dependency range for pyproj, version 3 of pyproj exists, and version 3 of pyproj depends on a version of libproj past what's available in the default ubuntu ppa.

```
pyproj==2.6.0
OWSLib==0.23.0
```

- fire up a python shell and make some services:

```python
from owslib import wcs, wmts, wms
wcs_service = wcs.wcs111.WebCoverageService_1_1_1("http://localhost:9000", None, None)
wmts_service = wmts.WebMapTileService("http://localhost:9000")
wms_service = wms.WebMapService("http://localhost:9000", version="1.3.0")
```

~~We can't make a `wms` service, because initializing the service with a url throws some kind of error about `'false'` not being a valid int. Unclear where the problem lies there.~~

- make some requests that return xml:
  - `wmts_service.getServiceXML()`
  - `wcs_service.getDescribeCoverage(None)`
  - `wms_service.getServiceXML()`

- `owslib` shouldn't complain about bad XML

Closes #298 