### PR TITLE
Reject requests with unsupported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Service endpoints reject requests with unsupported version parameters [#313](https://github.com/geotrellis/geotrellis-server/pull/313)
+
 ## [4.3.0] - 2021-02-12
 
 ## Added

--- a/ogc/src/main/scala/geotrellis/server/ogc/params/ParamError.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/params/ParamError.scala
@@ -58,6 +58,11 @@ object ParamError {
       s"""Unsupported format: '$format'"""
   }
 
+  final case class NoSupportedVersionError(requestedVersions: List[String], supportedVersions: List[String]) extends ParamError {
+    def errorMessage =
+      s"""No available version in ${supportedVersions.mkString(", ")}: ${requestedVersions.mkString(", ")}"""
+  }
+
   def generateErrorMessage(errors: List[ParamError]): String =
     errors.map(_.errorMessage).mkString("; ")
 }

--- a/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
@@ -83,16 +83,16 @@ case class ParamMap(params: Map[String, Seq[String]]) {
   def validatedVersion(default: String, supportedVersions: Set[String]): ValidatedNel[ParamError, String] =
     (getParams("version") match {
       case Some(version :: Nil) if supportedVersions.contains(version) => Valid(version)
-      case Some(Nil)                                          => Valid(default)
-      case Some(i :: Nil)                                     => Invalid(ParamError.InvalidValue("version", i, supportedVersions.toList))
-      case None                                               =>
+      case Some(Nil)                                                   => Valid(default)
+      case Some(i :: Nil)                                              => Invalid(ParamError.InvalidValue("version", i, supportedVersions.toList))
+      case None                                                        =>
         // Can send "acceptversions" instead
         getParams("acceptversions") match {
           case Some(Nil)             =>
             Valid(default)
           case Some(versions :: Nil) =>
             val requestedVersions = versions.split(",")
-            val intersection = (requestedVersions.toSet & supportedVersions)
+            val intersection      = requestedVersions.toSet & supportedVersions
             if (intersection.isEmpty) {
               Invalid(ParamError.NoSupportedVersionError(requestedVersions.toList, supportedVersions.toList))
             } else {

--- a/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
@@ -77,18 +77,24 @@ case class ParamMap(params: Map[String, Seq[String]]) {
       case None                                                  => Invalid(ParamError.MissingParam(field))
     }).toValidatedNel
 
-  def validatedVersion(default: String): ValidatedNel[ParamError, String] =
+  def validatedVersion(default: String, supportedVersions: Set[String]): ValidatedNel[ParamError, String] =
     (getParams("version") match {
-      case Some(Nil)            => Valid(default)
-      case Some(version :: Nil) => Valid(version)
-      case Some(_)              => Invalid(ParamError.RepeatedParam("version"))
-      case None                 =>
+      case Some(version :: Nil) if supportedVersions.contains(version) => Valid(version)
+      case Some(Nil)                                          => Valid(default)
+      case Some(i :: Nil)                                     => Invalid(ParamError.InvalidValue("version", i, supportedVersions.toList))
+      case None                                               =>
         // Can send "acceptversions" instead
         getParams("acceptversions") match {
           case Some(Nil)             =>
             Valid(default)
           case Some(versions :: Nil) =>
-            Valid(versions.split(",").max)
+            val requestedVersions = versions.split(",")
+            val intersection = (requestedVersions.toSet & supportedVersions)
+            if (intersection.isEmpty) {
+              Invalid(ParamError.NoSupportedVersionError(requestedVersions.toList, supportedVersions.toList))
+            } else {
+              Valid(intersection.max)
+            }
           case Some(_)               =>
             Invalid(ParamError.RepeatedParam("acceptversions"))
           case None                  =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/params/ParamMap.scala
@@ -77,6 +77,9 @@ case class ParamMap(params: Map[String, Seq[String]]) {
       case None                                                  => Invalid(ParamError.MissingParam(field))
     }).toValidatedNel
 
+  def validatedVersion(default: String): ValidatedNel[ParamError, String] =
+    validatedVersion(default, Set(default))
+
   def validatedVersion(default: String, supportedVersions: Set[String]): ValidatedNel[ParamError, String] =
     (getParams("version") match {
       case Some(version :: Nil) if supportedVersions.contains(version) => Valid(version)

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
@@ -138,14 +138,14 @@ object WcsParams {
 
 object GetCapabilitiesWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
     versionParam.map { version: String => GetCapabilitiesWcsParams(version) }
   }
 }
 
 object DescribeCoverageWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
 
     versionParam
       .andThen { version: String =>
@@ -176,7 +176,7 @@ object GetCoverageWcsParams {
     )
 
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
 
     versionParam
       .andThen { version: String =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
@@ -26,10 +26,13 @@ import geotrellis.vector.{Extent, ProjectedExtent}
 import cats.data.Validated._
 import cats.data.{Validated, ValidatedNel, NonEmptyList => NEL}
 import cats.syntax.apply._
+import cats.syntax.applicativeError._
 import cats.syntax.option._
+import cats.syntax.validated._
 
 import scala.util.Try
 import java.net.URI
+import geotrellis.server.ogc.params.ParamError.MissingParam
 
 abstract sealed class WcsParams {
   val version: String
@@ -108,6 +111,8 @@ case class GetCoverageWcsParams(
 
 object WcsParams {
 
+  val wcsVersion = "1.1.1"
+
   /** Defines valid request types, and the WcsParams to build from them. */
   private val requestMap: Map[String, ParamMap => ValidatedNel[ParamError, WcsParams]] =
     Map(
@@ -133,14 +138,14 @@ object WcsParams {
 
 object GetCapabilitiesWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion("1.1.1")
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
     versionParam.map { version: String => GetCapabilitiesWcsParams(version) }
   }
 }
 
 object DescribeCoverageWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion("1.1.1")
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
 
     versionParam
       .andThen { version: String =>
@@ -171,7 +176,7 @@ object GetCoverageWcsParams {
     )
 
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion("1.1.1")
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, Set(WcsParams.wcsVersion))
 
     versionParam
       .andThen { version: String =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
@@ -33,6 +33,9 @@ abstract sealed class WmsParams {
 }
 
 object WmsParams {
+
+  val wmsVersion = "1.3.0"
+
   final case class GetCapabilities(
     version: String,
     format: Option[String],
@@ -41,7 +44,7 @@ object WmsParams {
 
   object GetCapabilities {
     def build(params: ParamMap): ValidatedNel[ParamError, WmsParams] = {
-      (params.validatedVersion("1.3.0"), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
+      (params.validatedVersion(wmsVersion, Set(wmsVersion)), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
         .mapN(GetCapabilities.apply)
     }
   }
@@ -72,7 +75,7 @@ object WmsParams {
   object GetMap {
     def build(params: ParamMap): ValidatedNel[ParamError, WmsParams] = {
       val versionParam =
-        params.validatedVersion("1.3.0")
+        params.validatedVersion(wmsVersion, Set(wmsVersion))
 
       versionParam
         .andThen { version: String =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsParams.scala
@@ -44,7 +44,7 @@ object WmsParams {
 
   object GetCapabilities {
     def build(params: ParamMap): ValidatedNel[ParamError, WmsParams] = {
-      (params.validatedVersion(wmsVersion, Set(wmsVersion)), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
+      (params.validatedVersion(wmsVersion), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
         .mapN(GetCapabilities.apply)
     }
   }
@@ -75,7 +75,7 @@ object WmsParams {
   object GetMap {
     def build(params: ParamMap): ValidatedNel[ParamError, WmsParams] = {
       val versionParam =
-        params.validatedVersion(wmsVersion, Set(wmsVersion))
+        params.validatedVersion(wmsVersion)
 
       versionParam
         .andThen { version: String =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsParams.scala
@@ -44,7 +44,7 @@ object WmtsParams {
 
   object GetCapabilities {
     def build(params: ParamMap): ValidatedNel[ParamError, WmtsParams] = {
-      (params.validatedVersion(wmtsVersion, Set(wmtsVersion)), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
+      (params.validatedVersion(wmtsVersion), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
         .mapN(GetCapabilities.apply)
     }
   }
@@ -66,7 +66,7 @@ object WmtsParams {
     def build(params: ParamMap): ValidatedNel[ParamError, WmtsParams] = {
       logger.trace(s"PARAM MAP: ${params.params}")
       val versionParam =
-        params.validatedVersion(wmtsVersion, Set(wmtsVersion))
+        params.validatedVersion(wmtsVersion)
 
       versionParam
         .andThen { version: String =>

--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsParams.scala
@@ -34,6 +34,8 @@ abstract sealed class WmtsParams {
 object WmtsParams {
   lazy val logger = org.log4s.getLogger
 
+  val wmtsVersion = "1.0.0"
+
   final case class GetCapabilities(
     version: String,
     format: Option[String],
@@ -42,7 +44,7 @@ object WmtsParams {
 
   object GetCapabilities {
     def build(params: ParamMap): ValidatedNel[ParamError, WmtsParams] = {
-      (params.validatedVersion("1.0.0"), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
+      (params.validatedVersion(wmtsVersion, Set(wmtsVersion)), params.validatedOptionalParam("format"), params.validatedOptionalParam("updatesequence"))
         .mapN(GetCapabilities.apply)
     }
   }
@@ -64,7 +66,7 @@ object WmtsParams {
     def build(params: ParamMap): ValidatedNel[ParamError, WmtsParams] = {
       logger.trace(s"PARAM MAP: ${params.params}")
       val versionParam =
-        params.validatedVersion("1.0.0")
+        params.validatedVersion(wmtsVersion, Set(wmtsVersion))
 
       versionParam
         .andThen { version: String =>


### PR DESCRIPTION
## Overview

This PR updates the version param validation logic to take a param of which versions are supported. As the validation logic was written before, it was happy to take any string as the `version` param, which led unexpected successes for versions that don't match
what the server is actually capable of.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

```bash
$ http :9000 service==wmts request==getcapabilities acceptVersions==1.0.1,1.1.0,1.1.2
HTTP/1.1 400 Bad Request
Content-Length: 50
Content-Type: text/plain; charset=UTF-8
Date: Mon, 15 Feb 2021 21:24:31 GMT

No available version in 1.0.0: 1.0.1, 1.1.0, 1.1.2

$ http :9000 service==wmts request==getcapabilities version==900
HTTP/1.1 400 Bad Request
Content-Length: 76
Content-Type: text/plain; charset=UTF-8
Date: Mon, 15 Feb 2021 21:31:59 GMT

Parameter 'version' has an invalid value of '900'. Needs to be one of: 1.0.0
```

## Testing Instructions

- bring up ogc-example project
- make some `GetCapabilities` requests as above for wcs, wms, and wmts services using supported versions (1.1.1, 1.3.0, and 1.0.0, respectively)
- make similar requests for unsupported versions (anything else)
- make similar requests with `acceptedVersions` set to a comma-separated list that _includes_ the valid version -- this should work
- make similar requests with `acceptedVersions` set to a comma-separated list that _excludes_ the valid version -- this should give you a 400

Closes #307 