### PR TITLE
Support configurable CRS in WCS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Fixed
-
 - Service endpoints reject requests with unsupported version parameters [#313](https://github.com/geotrellis/geotrellis-server/pull/313)
+
+## Added
+- WCS services support configuration of `supported-projections` [#314](https://github.com/geotrellis/geotrellis-server/pull/314)
 
 ## [4.3.0] - 2021-02-12
 

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -68,8 +68,17 @@ wcs = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.markham},
-      ${layers.lc8-rgb}
+      ${layers.lc8-rgb},
+      ${layers.markham}
+    ]
+    supported-projections = [
+        4326,
+        3410,
+        3978,
+        4617,
+        3979,
+        3413,
+        26916
     ]
 }
 

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -43,8 +43,8 @@ wms = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.markham},
-      ${layers.lc8-rgb}
+      ${layers.lc8-rgb},
+      ${layers.markham}
     ]
 }
 
@@ -102,8 +102,8 @@ wmts = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.markham},
-      ${layers.lc8-rgb}
+      ${layers.lc8-rgb},
+      ${layers.markham}
     ]
     tile-matrix-sets = [
         {

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -155,6 +155,7 @@ object Main
                                     WcsModel[IO](
                                       svc.serviceMetadata,
                                       svc.layerSources(simpleSources),
+                                      svc.supportedProjections,
                                       ExtendedParameters.extendedParametersBinding
                                     )
                                   }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -21,6 +21,7 @@ import geotrellis.server.ogc.{ows, MapAlgebraSource, OgcSource, RasterOgcSource}
 import geotrellis.server.ogc.wms.WmsParentLayerMeta
 import geotrellis.server.ogc.wmts.GeotrellisTileMatrixSet
 import geotrellis.store.query.Repository
+import geotrellis.proj4.CRS
 
 /**
   * Each service has its own unique configuration requirements (see the below instances)
@@ -55,5 +56,6 @@ case class WmtsConf(
 /** WCS Service configuration */
 case class WcsConf(
   serviceMetadata: ows.ServiceMetadata,
-  layerDefinitions: List[OgcSourceConf]
+  layerDefinitions: List[OgcSourceConf],
+  supportedProjections: List[CRS]
 ) extends OgcServiceConf

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -23,11 +23,13 @@ import com.azavea.maml.ast.Expression
 import cats.Functor
 import cats.syntax.functor._
 import geotrellis.store.query.RepositoryM
+import geotrellis.proj4.CRS
 
 /** This class holds all the information necessary to construct a response to a WCS request */
 case class WcsModel[F[_]: Functor](
   serviceMetadata: ows.ServiceMetadata,
   sources: RepositoryM[F, List, OgcSource],
+  supportedProjections: List[CRS],
   extendedParametersBinding: Option[ParamMap => Option[Expression => Expression]] = None
 ) {
   def getLayers(p: GetCoverageWcsParams): F[List[OgcLayer]] = {

--- a/stac-example/src/main/resources/application.conf
+++ b/stac-example/src/main/resources/application.conf
@@ -86,6 +86,16 @@ wcs = {
         ${layers.stac-lc8-blue-pa},
         ${layers.stac-lc8-rgb-pa}
     ]
+    supported-projections = [
+        4326,
+        3410,
+        3978,
+        4617,
+        3979,
+        3413,
+        3857,
+        26916
+    ]
 }
 
 wmts = {

--- a/stac-example/src/main/scala/geotrellis/server/ogc/Main.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/Main.scala
@@ -157,6 +157,7 @@ object Main
                                     WcsModel[IO](
                                       svc.serviceMetadata,
                                       svc.layerSources(simpleSources, http4sClient),
+                                      svc.supportedProjections,
                                       ExtendedParameters.extendedParametersBinding
                                     )
                                   }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -20,6 +20,7 @@ import cats.SemigroupK
 import cats.effect.Sync
 import cats.instances.list._
 import cats.syntax.semigroup._
+import geotrellis.proj4.CRS
 import geotrellis.server.ogc
 import geotrellis.server.ogc.{ows, MapAlgebraSource, OgcSource, RasterOgcSource}
 import geotrellis.server.ogc.wms.WmsParentLayerMeta
@@ -72,5 +73,6 @@ case class WmtsConf(
 /** WCS Service configuration */
 case class WcsConf(
   serviceMetadata: ows.ServiceMetadata,
-  layerDefinitions: List[OgcSourceConf]
+  layerDefinitions: List[OgcSourceConf],
+  supportedProjections: List[CRS]
 ) extends OgcServiceConf


### PR DESCRIPTION
## Overview

This PR adds a `supportedProjections` attribute to the `WcsConf` case class, adds example configuration to the `stac-example` and `ogc-example` projects, and consumes those supported projections when rendering the `GetCapabilities` response.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

```bash
$ http :9000 service==wcs request==getcapabilities
HTTP/1.1 200 OK
Content-Length: 8925
Content-Type: application/xml
Date: Tue, 16 Feb 2021 16:46:01 GMT

...
<CoverageSummary>
  <ows:Title>US NED</ows:Title>
  <ows:WGS84BoundingBox>
    <ows:LowerCorner>-15.015761449275047 -171.00056648254395</ows:LowerCorner>
    <ows:UpperCorner>72.00056298703436 164.00399450196636</ows:UpperCorner>
  </ows:WGS84BoundingBox>
  <SupportedCRS>urn:ogc:def:crs:OGC::imageCRS</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::3785</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::3410</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::3978</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::4617</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::3979</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::3413</SupportedCRS>
  <SupportedCRS>urn:ogc:def:crs:EPSG::26916</SupportedCRS>
  <SupportedFormat>image/geotiff</SupportedFormat>
  <SupportedFormat>image/jpeg</SupportedFormat>
  <SupportedFormat>image/png</SupportedFormat>
  <Identifier>us-ned</Identifier>
</CoverageSummary>
...
```

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- make the demo request with the ogc-example project running
- confirm you also see the CRSes that match the values from the `application.conf`
- optional: change those values and verify the server respects your changes

Closes #305 
