### PR TITLE
Add WCS 1.1.0 as the supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - WCS services support configuration of `supported-projections` [#314](https://github.com/geotrellis/geotrellis-server/pull/314)
+- Add WCS 1.1.0 as the supported version [#330](https://github.com/geotrellis/geotrellis-server/pull/330)
 
 ## [4.3.0] - 2021-02-12
 

--- a/ogc-example/src/main/resources/application.conf
+++ b/ogc-example/src/main/resources/application.conf
@@ -43,8 +43,8 @@ wms = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.lc8-rgb},
-      ${layers.markham}
+      ${layers.markham},
+      ${layers.lc8-rgb}
     ]
 }
 
@@ -68,8 +68,8 @@ wcs = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.lc8-rgb},
-      ${layers.markham}
+      ${layers.markham},
+      ${layers.lc8-rgb}
     ]
     supported-projections = [
         4326,
@@ -102,8 +102,8 @@ wmts = {
       ${layers.us-ned-slope},
       ${layers.us-ned-hillshade},
       ${layers.us-census-median-household-income},
-      ${layers.lc8-rgb},
-      ${layers.markham}
+      ${layers.markham},
+      ${layers.lc8-rgb}
     ]
     tile-matrix-sets = [
         {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsParams.scala
@@ -111,7 +111,8 @@ case class GetCoverageWcsParams(
 
 object WcsParams {
 
-  val wcsVersion = "1.1.1"
+  val wcsVersion  = "1.1.1"
+  val wcsVersions = Set(wcsVersion, "1.1.0")
 
   /** Defines valid request types, and the WcsParams to build from them. */
   private val requestMap: Map[String, ParamMap => ValidatedNel[ParamError, WcsParams]] =
@@ -138,14 +139,14 @@ object WcsParams {
 
 object GetCapabilitiesWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, WcsParams.wcsVersions)
     versionParam.map { version: String => GetCapabilitiesWcsParams(version) }
   }
 }
 
 object DescribeCoverageWcsParams {
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, WcsParams.wcsVersions)
 
     versionParam
       .andThen { version: String =>
@@ -176,7 +177,7 @@ object GetCoverageWcsParams {
     )
 
   def build(params: ParamMap): ValidatedNel[ParamError, WcsParams] = {
-    val versionParam = params.validatedVersion(WcsParams.wcsVersion)
+    val versionParam = params.validatedVersion(WcsParams.wcsVersion, WcsParams.wcsVersions)
 
     versionParam
       .andThen { version: String =>


### PR DESCRIPTION
## Overview

https://github.com/geotrellis/geotrellis-server/pull/313 introduced endpoints versions check, it revealed that QGIS supports only WCS 1.0 and 1.1.0. This change makes QGIS queries compatible with the current WCS service.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible
