### PR TITLE
STAC collections support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - WCS services support configuration of `supported-projections` [#314](https://github.com/geotrellis/geotrellis-server/pull/314)
 - Add WCS 1.1.0 as the supported version [#330](https://github.com/geotrellis/geotrellis-server/pull/330)
+- STAC Collections support [#338](https://github.com/geotrellis/geotrellis-server/issues/338)
 
 ### Changed
 - Update GT Server STAC4S dependency [#319](https://github.com/geotrellis/geotrellis-server/issues/319)

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcServiceConf.scala
@@ -50,7 +50,7 @@ sealed trait OgcServiceConf {
     rasterOgcSources: List[RasterOgcSource],
     client: SttpBackend[F, Any]
   ): RepositoryM[F, List, OgcSource] = {
-    val stacLayers: List[StacSourceConf]                 = layerDefinitions.collect { case ssc @ StacSourceConf(_, _, _, _, _, _, _, _, _, _, _, _, _, _) => ssc }
+    val stacLayers: List[StacSourceConf]                 = layerDefinitions.collect { case ssc @ StacSourceConf(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => ssc }
     val mapAlgebraConfLayers: List[MapAlgebraSourceConf] = layerDefinitions.collect { case masc @ MapAlgebraSourceConf(_, _, _, _, _, _, _) => masc }
 
     layerSources(rasterOgcSources).toF[F] |+|

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacOgcRepositories.scala
@@ -47,7 +47,7 @@ case class StacOgcRepository[F[_]: Sync: Logger](
   def find(query: Query): F[List[OgcSource]] = {
 
     /** Replace the actual conf name with the STAC Layer name */
-    val filters = SearchFilters.eval(query.overrideName(stacSourceConf.layer))
+    val filters: Option[SearchFilters] = SearchFilters.eval(stacSourceConf.searchCriteria)(query.overrideName(stacSourceConf.searchName))
     filters.fold(List.empty[OgcSource].pure[F]) { filter =>
       client
         .search(filter.copy(limit = stacSourceConf.assetLimit))

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacSearchCriteria.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/StacSearchCriteria.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.server.ogc.stac
+
+sealed trait StacSearchCriteria
+case object ByLayer      extends StacSearchCriteria
+case object ByCollection extends StacSearchCriteria

--- a/stac-example/src/main/scala/geotrellis/server/ogc/stac/package.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/stac/package.scala
@@ -35,6 +35,6 @@ package object stac {
   }
 
   implicit class SearchFiltersObjOps(val self: SearchFilters.type) extends AnyVal {
-    def eval(query: Query): Option[SearchFilters] = SearchFiltersQuery.eval(query)
+    def eval(stacSearchCriteria: StacSearchCriteria)(query: Query): Option[SearchFilters] = SearchFiltersQuery.eval(stacSearchCriteria)(query)
   }
 }


### PR DESCRIPTION
## Overview

This PR adds backwards compatible collections support in case the STAC Catalog does not use the STAC Layer extension.

### Demo

```javascript
    stac-hillshade-buffered = {
        type = "stacsourceconf"
        // ...
        // this can be collection
        collection = "hillshade-buffered"
        // or layer
        layer = "hillshade-buffered"
        // ...
    }
```

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

Closes #338