### PR TITLE
Fix WCS DescribeCoverage extents axis ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - WMS Parent Layer default time should be omitted [#368](https://github.com/geotrellis/geotrellis-server/pull/368)
+- Fix WCS DescribeCoverage extents axis ordering [#369](https://github.com/geotrellis/geotrellis-server/pull/369)
 
 ## [4.4.0] - 2021-04-30
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/CoverageView.scala
@@ -147,7 +147,7 @@ object CoverageView {
               )
             )
           ) :: uniqueCrs.flatMap {
-            case crs if crs == LatLng =>
+            case crs if crs == LatLng    =>
               val lex = extractGridExtent(source, crs).extent
               OwsDataRecord(
                 BoundingBoxType(
@@ -167,12 +167,24 @@ object CoverageView {
                   )
                 )
               ) :: Nil
-            case crs                  =>
+            case crs if crs.isGeographic =>
               val lex = extractGridExtent(source, crs).extent
               OwsDataRecord(
                 BoundingBoxType(
                   LowerCorner = lex.ymin :: lex.xmin :: Nil,
                   UpperCorner = lex.ymax :: lex.xmax :: Nil,
+                  attributes = Map(
+                    "@crs"        -> DataRecord(new URI(URN.unsafeFromCrs(crs))),
+                    "@dimensions" -> DataRecord(BigInt(2))
+                  )
+                )
+              ) :: Nil
+            case crs                     =>
+              val lex = extractGridExtent(source, crs).extent
+              OwsDataRecord(
+                BoundingBoxType(
+                  LowerCorner = lex.xmin :: lex.ymin :: Nil,
+                  UpperCorner = lex.xmax :: lex.ymax :: Nil,
                   attributes = Map(
                     "@crs"        -> DataRecord(new URI(URN.unsafeFromCrs(crs))),
                     "@dimensions" -> DataRecord(BigInt(2))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.5.2

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.1"
-declare -r sbt_unreleased_version="1.5.1"
+declare -r sbt_release_version="1.5.2"
+declare -r sbt_unreleased_version="1.5.2"
 
 declare -r latest_213="2.13.5"
 declare -r latest_212="2.12.13"


### PR DESCRIPTION
## Overview

This PR Fixes WCS DescribeCoverage extents axis ordering.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

