### PR TITLE
Expose MAML layers targetCellType

### DIFF
--- a/core/src/main/scala/geotrellis/server/LayerExtent.scala
+++ b/core/src/main/scala/geotrellis/server/LayerExtent.scala
@@ -98,12 +98,4 @@ object LayerExtent {
       val eval = curried(RasterVar("identity"), ConcurrentInterpreter.DEFAULT, cellType.some)
       eval(Map("identity" -> param), extent, cellsize)
     }
-
-  def identity[F[_]: Logger: Parallel: Monad: Concurrent, T: ExtentReification[F, *]](
-    param: T
-  ): (Extent, Option[CellSize]) => F[Interpreted[MultibandTile]] =
-    (extent: Extent, cellsize: Option[CellSize]) => {
-      val eval = curried(RasterVar("identity"), ConcurrentInterpreter.DEFAULT, None)
-      eval(Map("identity" -> param), extent, cellsize)
-    }
 }

--- a/core/src/main/scala/geotrellis/server/LayerTms.scala
+++ b/core/src/main/scala/geotrellis/server/LayerTms.scala
@@ -110,12 +110,4 @@ object LayerTms {
       val eval = curried[F, T](RasterVar("identity"), ConcurrentInterpreter.DEFAULT, cellType.some)
       eval(Map("identity" -> param), z, x, y)
     }
-
-  def identity[F[_]: Logger: Parallel: Monad: Concurrent, T: TmsReification[F, *]](
-    param: T
-  ): (Int, Int, Int) => F[Interpreted[MultibandTile]] =
-    (z: Int, x: Int, y: Int) => {
-      val eval = curried[F, T](RasterVar("identity"), ConcurrentInterpreter.DEFAULT, None)
-      eval(Map("identity" -> param), z, x, y)
-    }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -16,7 +16,7 @@
 
 package geotrellis.server.ogc.conf
 
-import geotrellis.raster.RasterSource
+import geotrellis.raster.{CellType, RasterSource}
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample._
 import geotrellis.server.ogc._
@@ -85,7 +85,8 @@ case class MapAlgebraSourceConf(
   resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
   overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   timeFormat: OgcTimeFormat = OgcTimeFormat.Default,
-  timeDefault: OgcTimeDefault = OgcTimeDefault.Oldest
+  timeDefault: OgcTimeDefault = OgcTimeDefault.Oldest,
+  targetCellType: Option[CellType] = None
 ) extends OgcSourceConf {
   private def listParams(expr: Expression): List[String] = {
     def eval(subExpr: Expression): List[String] =
@@ -122,7 +123,8 @@ case class MapAlgebraSourceConf(
       resampleMethod,
       overviewStrategy,
       timeFormat,
-      timeDefault
+      timeDefault,
+      targetCellType
     )
   }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -20,7 +20,7 @@ import geotrellis.server.ogc.wms.wmsScope
 import geotrellis.server.ogc.style._
 import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
-import geotrellis.raster.{resample, ResampleMethod, TileLayout}
+import geotrellis.raster.{resample, CellType, ResampleMethod, TileLayout}
 import geotrellis.raster.render.{ColorMap, ColorRamp}
 import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
@@ -192,4 +192,7 @@ package object conf {
 
   implicit val ogcTimeDefaultReader: ConfigReader[OgcTimeDefault] =
     ConfigReader[String].emap { _.asJson.as[OgcTimeDefault].leftMap(e => ExceptionThrown(e.fillInStackTrace())) }
+
+  implicit val cellTypeReader: ConfigReader[CellType] =
+    ConfigReader[String].emap { _.asJson.as[CellType].leftMap(e => ExceptionThrown(e.fillInStackTrace())) }
 }

--- a/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/ogc-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -85,7 +85,7 @@ class WmtsView[F[_]: Concurrent: Parallel: ApplicativeThrow: Logger](
                 val evalWmts = layer match {
                   case sl: SimpleTiledOgcLayer      => LayerTms.withCellType(sl, sl.source.cellType)
                   case mas: MapAlgebraTiledOgcLayer =>
-                    LayerTms.concurrent(mas.algebra.pure[F], mas.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F])
+                    LayerTms(mas.algebra.pure[F], mas.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F], mas.targetCellType)
                 }
 
                 // TODO: remove this once GeoTiffRasterSource would be threadsafe

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcLayer.scala
@@ -68,7 +68,8 @@ case class MapAlgebraOgcLayer(
   algebra: Expression,
   style: Option[OgcStyle],
   resampleMethod: ResampleMethod,
-  overviewStrategy: OverviewStrategy
+  overviewStrategy: OverviewStrategy,
+  targetCellType: Option[CellType]
 ) extends OgcLayer
 
 object SimpleOgcLayer {

--- a/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/OgcSource.scala
@@ -223,7 +223,8 @@ case class MapAlgebraSource(
   resampleMethod: ResampleMethod,
   overviewStrategy: OverviewStrategy,
   timeFormat: OgcTimeFormat,
-  timeDefault: OgcTimeDefault
+  timeDefault: OgcTimeDefault,
+  targetCellType: Option[CellType]
 ) extends OgcSource {
   // each of the underlying ogcSources uses it's own timeMetadataKey
   val timeMetadataKey: Option[String] = None

--- a/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/TiledOgcLayer.scala
@@ -66,7 +66,8 @@ case class MapAlgebraTiledOgcLayer(
   algebra: Expression,
   style: Option[OgcStyle],
   resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
-  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT
+  overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT,
+  targetCellType: Option[CellType] = None
 ) extends TiledOgcLayer
 
 object SimpleTiledOgcLayer {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/GetCoverage.scala
@@ -48,7 +48,7 @@ class GetCoverage[F[_]: Concurrent: Parallel: Logger](wcsModel: WcsModel[F]) {
         _.headOption
           .map {
             case so: SimpleOgcLayer      => LayerExtent.withCellType(so, so.source.cellType)
-            case mal: MapAlgebraOgcLayer => LayerExtent.concurrent(mal.algebra.pure[F], mal.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F])
+            case mal: MapAlgebraOgcLayer => LayerExtent(mal.algebra.pure[F], mal.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F], mal.targetCellType)
           }
           .traverse { eval =>
             eval(e, cs) map {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wcs/WcsModel.scala
@@ -49,7 +49,8 @@ case class WcsModel[F[_]: Functor](
             algebra.bindExtendedParameters(extendedParameters),
             None,
             resampleMethod,
-            overviewStrategy
+            overviewStrategy,
+            mas.targetCellType
           )
       }
     }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfo.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfo.scala
@@ -54,7 +54,7 @@ case class GetFeatureInfo[F[_]: Logger: Parallel: Concurrent: ApplicativeThrow](
           .map { layer =>
             val evalExtent = layer match {
               case sl: SimpleOgcLayer     => LayerExtent.withCellType(sl, sl.source.cellType)
-              case ml: MapAlgebraOgcLayer => LayerExtent.concurrent(ml.algebra.pure[F], ml.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F])
+              case ml: MapAlgebraOgcLayer => LayerExtent(ml.algebra.pure[F], ml.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F], ml.targetCellType)
             }
 
             evalExtent(re.extent, re.cellSize.some).map {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/GetMap.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/GetMap.scala
@@ -52,7 +52,7 @@ case class GetMap[F[_]: Logger: Parallel: Concurrent: ApplicativeThrow](
             val evalExtent = layer match {
               case sl: SimpleOgcLayer     => LayerExtent.withCellType(sl, sl.source.cellType)
               case ml: MapAlgebraOgcLayer =>
-                LayerExtent.concurrent(ml.algebra.pure[F], ml.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F])
+                LayerExtent(ml.algebra.pure[F], ml.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F], ml.targetCellType)
             }
 
             val evalHisto = layer match {

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/WmsModel.scala
@@ -69,7 +69,8 @@ case class WmsModel[F[_]: Monad](
                   algebra.bindExtendedParameters(extendedParameters),
                   style,
                   resampleMethod,
-                  overviewStrategy
+                  overviewStrategy,
+                  mas.targetCellType
                 )
             }
           }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/OgcSourceConf.scala
@@ -17,8 +17,7 @@
 package geotrellis.server.ogc.conf
 
 import geotrellis.server.ogc.stac.{ByCollection, ByLayer, StacSearchCriteria}
-
-import geotrellis.raster.RasterSource
+import geotrellis.raster.{CellType, RasterSource}
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample._
 import geotrellis.server.ogc._
@@ -157,7 +156,8 @@ case class MapAlgebraSourceConf(
   resampleMethod: ResampleMethod = ResampleMethod.DEFAULT,
   overviewStrategy: OverviewStrategy = OverviewStrategy.DEFAULT,
   timeFormat: OgcTimeFormat = OgcTimeFormat.Default,
-  timeDefault: OgcTimeDefault = OgcTimeDefault.Oldest
+  timeDefault: OgcTimeDefault = OgcTimeDefault.Oldest,
+  targetCellType: Option[CellType] = None
 ) extends OgcSourceConf {
   def listParams(expr: Expression): List[String] = {
     def eval(subExpr: Expression): List[String] =
@@ -192,7 +192,8 @@ case class MapAlgebraSourceConf(
       resampleMethod,
       overviewStrategy,
       timeFormat,
-      timeDefault
+      timeDefault,
+      targetCellType
     )
   }
 
@@ -210,7 +211,8 @@ case class MapAlgebraSourceConf(
         resampleMethod,
         overviewStrategy,
         timeFormat,
-        timeDefault
+        timeDefault,
+        targetCellType
       ).some
     else None
   }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/conf/package.scala
@@ -20,7 +20,7 @@ import geotrellis.server.ogc.wms.wmsScope
 import geotrellis.server.ogc.style._
 import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
-import geotrellis.raster.{resample, ResampleMethod, TileLayout}
+import geotrellis.raster.{resample, CellType, ResampleMethod, TileLayout}
 import geotrellis.raster.render.{ColorMap, ColorRamp}
 import com.azavea.maml.ast._
 import com.azavea.maml.ast.codec.tree._
@@ -193,4 +193,7 @@ package object conf {
 
   implicit val ogcTimeDefaultReader: ConfigReader[OgcTimeDefault] =
     ConfigReader[String].emap { _.asJson.as[OgcTimeDefault].leftMap(e => ExceptionThrown(e.fillInStackTrace())) }
+
+  implicit val cellTypeReader: ConfigReader[CellType] =
+    ConfigReader[String].emap { _.asJson.as[CellType].leftMap(e => ExceptionThrown(e.fillInStackTrace())) }
 }

--- a/stac-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
+++ b/stac-example/src/main/scala/geotrellis/server/ogc/wmts/WmtsView.scala
@@ -84,7 +84,7 @@ class WmtsView[F[_]: Concurrent: Parallel: ApplicativeThrow: Logger](
                 val evalWmts = layer match {
                   case sl: SimpleTiledOgcLayer      => LayerTms.withCellType(sl, sl.source.cellType)
                   case mas: MapAlgebraTiledOgcLayer =>
-                    LayerTms.concurrent(mas.algebra.pure[F], mas.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F])
+                    LayerTms(mas.algebra.pure[F], mas.parameters.pure[F], ConcurrentInterpreter.DEFAULT[F], mas.targetCellType)
                 }
 
                 // TODO: remove this once GeoTiffRasterSource would be threadsafe


### PR DESCRIPTION
## Overview

This PR adds an optional configuration option to all MAML layers. If set than the result layer would be lazily interpreted as a layer with the given cellType.

### Checklist

- [ ] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

```js
stac-lc8-rgb = {
  type = "mapalgebrasourceconf"
  name = "stac-lc8-rgb"
  title = "Landsat LayerUS RGB"
  target-cell-type = "int32raw" // or whatever supported by GeoTrellis
  // ...
}
```

