### PR TITLE
Fix InterpolatedColorMap.render function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WMS Parent Layer default time should be omitted [#368](https://github.com/geotrellis/geotrellis-server/pull/368)
 - Fix WCS DescribeCoverage extents axis ordering [#369](https://github.com/geotrellis/geotrellis-server/pull/369)
 - Fix TIFF CellType of identity MAML Layers [#375](https://github.com/geotrellis/geotrellis-server/pull/375)
+- Fix InterpolatedColorMap.render function [#381](https://github.com/geotrellis/geotrellis-server/pull/381)
 
 ## Changed
 - OgcTime logic cleanup [#371](https://github.com/geotrellis/geotrellis-server/pull/371)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
 
   val dispatchVer  = "0.11.3"
   val gtVer        = "3.6.0"
-  val stac4sVer    = "0.5.0-8-gaab61a6-SNAPSHOT"
+  val stac4sVer    = "0.5.0-13-g35ad8d4-SNAPSHOT"
   val jaxbApiVer   = "2.3.1"
   val refinedVer   = "0.9.20"
   val shapelessVer = "2.3.3"


### PR DESCRIPTION
## Overview

This PR fixes a not completely correct InterpolatedColorMap.render. https://github.com/geotrellis/geotrellis-server/pull/375 preserves the source cellType, but what if it doesn't allow to encoder the interpolated color map result? 

ColorMap.render properly handles it and this PR replicates its behavior to match.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible
