### PR TITLE
GetFeatureInfo and GetFeatureInfoExtended pixel values field name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - STAC Assets regex selectors support [#388](https://github.com/geotrellis/geotrellis-server/pull/388)
+- GetFeatureInfo and GetFeatureInfoExtended pixel values field name change [#389](https://github.com/geotrellis/geotrellis-server/pull/389)
 
 ## [4.5.0] - 2021-07-10
 

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfo.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfo.scala
@@ -94,7 +94,7 @@ case class GetFeatureInfo[F[_]: Logger: Parallel: Concurrent: ApplicativeThrow](
       Right(
         Feature(
           Point(raster.rasterExtent.gridToMap(params.i, params.j)),
-          raster.tile.bands.zipWithIndex.map { case (b, i) => s"band-$i-pixel-value" -> b.getDouble(params.i, params.j) }.toMap.asJson
+          raster.tile.bands.zipWithIndex.map { case (b, i) => s"band-$i-value" -> b.getDouble(params.i, params.j) }.toMap.asJson
         )
       )
   }

--- a/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfoExtended.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wms/GetFeatureInfoExtended.scala
@@ -114,6 +114,6 @@ case class GetFeatureInfoExtended[F[_]: Logger: Parallel: Concurrent: Applicativ
     p: Point
   ): Either[GetFeatureInfoException, Feature[Geometry, Json]] = {
     val (c, r) = raster.rasterExtent.mapToGrid(p)
-    Right(Feature(p, raster.tile.bands.zipWithIndex.map { case (b, i) => s"band-$i-pixel-value" -> b.getDouble(c, r) }.toMap.asJson))
+    Right(Feature(p, raster.tile.bands.zipWithIndex.map { case (b, i) => s"band-$i-value" -> b.getDouble(c, r) }.toMap.asJson))
   }
 }


### PR DESCRIPTION
## Overview

This PR changes the json / xml field name:

* `s"band-$i-pixel-value"` => `s"band-$i-value"`

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

### Demo

```json
{
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.954221646931719,
                    55.19328859044019
                ]
            },
            "properties": {
                "band-0-value": 30.0
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.954221646931719,
                    56.19328859044019
                ]
            },
            "properties": {
                "band-0-value": 27.0
            }
        }
    ]
}
```
