### PR TITLE
Add Rasterio Affine Transform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Add Azure RangeReaders [#386](https://github.com/geotrellis/geotrellis-server/pull/386)
 - Add GetFeatureInfoExtended support [#388](https://github.com/geotrellis/geotrellis-server/pull/388)
+- Add Rasterio Affine Transform support [#390](https://github.com/geotrellis/geotrellis-server/pull/390)
 
 ## Changed
 - STAC Assets regex selectors support [#388](https://github.com/geotrellis/geotrellis-server/pull/388)

--- a/stac/src/main/scala/geotrellis/stac/extensions/proj/ProjTransform.scala
+++ b/stac/src/main/scala/geotrellis/stac/extensions/proj/ProjTransform.scala
@@ -41,6 +41,13 @@ object ProjTransform {
 
   def apply(transform: List[Double]): Either[String, ProjTransform] = apply(transform.toArray)
 
-  implicit val enProjGDALTransform: Encoder[ProjTransform]  = Encoder.encodeList[Double].contramap(_.toList)
-  implicit val decProjGDALTransform: Decoder[ProjTransform] = Decoder.decodeList[Double].emap(ProjTransform.apply)
+  implicit val enProjGDALTransform: Encoder[ProjTransform] = Encoder.encodeList[Double].contramap(_.toList)
+  implicit val decProjGDALTransform: Decoder[ProjTransform] = Decoder.decodeList[Double].emap { list =>
+    val transform = if (list.length > 6) {
+      // handle rasterio affine transform
+      val List(a, b, c, d, e, f) = list.take(6)
+      List(c, a, b, f, d, e)
+    } else list
+    apply(transform)
+  }
 }

--- a/stac/src/main/scala/geotrellis/stac/package.scala
+++ b/stac/src/main/scala/geotrellis/stac/package.scala
@@ -30,7 +30,7 @@ import io.circe.syntax._
 import io.circe.generic.extras.Configuration
 
 package object stac {
-  implicit lazy val configuration: Configuration = Configuration.default.withSnakeCaseMemberNames
+  implicit lazy val configuration: Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
 
   implicit class ExtentOps(val self: Extent) extends AnyVal {
     def toTwoDimBbox: TwoDimBbox = {


### PR DESCRIPTION
## Overview

This PR adds a more flexible STAC Projection extension parsing support

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

