### PR TITLE
WMTSModel add GeoTrellisOgcSource match item

### DIFF
--- a/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
+++ b/ogc/src/main/scala/geotrellis/server/ogc/wmts/WmtsModel.scala
@@ -61,6 +61,8 @@ case class WmtsModel[F[_]: Monad](
               MapAlgebraTiledOgcLayer(name, title, crs, layout, simpleLayers, algebra, style, resampleMethod, overviewStrategy)
             case ss: SimpleSource =>
               SimpleTiledOgcLayer(ss.name, ss.title, crs, layout, ss.source, style, ss.resampleMethod, ss.overviewStrategy)
+            case gos: GeoTrellisOgcSource =>
+              SimpleTiledOgcLayer(gos.name, gos.title, crs, layout, gos.source, style, gos.resampleMethod, gos.overviewStrategy)
           }
         }
       }


### PR DESCRIPTION
## Overview

WMTS does not support GT Layer now, it's necessary to add GeoTrellisOgcSource to WMTSModel.

